### PR TITLE
Support IE11 window scroll offset

### DIFF
--- a/src/platform/web/scrollcomponent/ScrollEventNormalizer.ts
+++ b/src/platform/web/scrollcomponent/ScrollEventNormalizer.ts
@@ -36,10 +36,10 @@ export class ScrollEventNormalizer {
             nativeEvent: {
                 contentOffset: {
                     get x(): number {
-                        return window.scrollX;
+                        return window.scrollX === undefined ? window.pageXOffset : window.scrollX;
                     },
                     get y(): number {
-                        return window.scrollY;
+                        return window.scrollY === undefined ? window.pageYOffset : window.scrollY;
                     },
                 },
                 contentSize: {


### PR DESCRIPTION
The `window.scrollX` and `window.scrollY` properties are not supported by IE11. As far as I could tell all that is required to add support is to use `window.pageX/YOffset` in that case.