### PR TITLE
Implements getViewHolderForType on ViewRenderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Apart from all performance benefits RecyclerListView comes with great features o
 - Non deterministic rendering mode on demand (height cannot be determined before rendering)
 - (New) ItemAnimator interface added, customize to your will how RLV handles layout changes. Allows you to modify animations that move cells. You can do things like smoothly move an item to a new position when height of one of the cells has changed.
 - (New) Stable Id support, ability to associate a stable id with an item. Will enable beautiful add/remove animations and optimize re-renders when DataProvider is updated.
+- (New) Pass in custom View wrapper for ViewRenderer, useful for implementing sorting.
 
 ## Why?
 

--- a/src/core/RecyclerListView.tsx
+++ b/src/core/RecyclerListView.tsx
@@ -108,6 +108,7 @@ export interface RecyclerListViewProps {
     optimizeForInsertDeleteAnimations?: boolean;
     style?: object;
     debugHandlers?: DebugHandlers;
+    getViewHolderForType?: (type: string | number) => JSX.Element;
 
     //For all props that need to be proxied to inner/external scrollview. Put them in an object and they'll be spread
     //and passed down. For better typescript support.
@@ -486,21 +487,22 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
             }
             return (
                 <ViewRenderer key={key} data={data}
-                              dataHasChanged={this._dataHasChanged}
-                              x={itemRect.x}
-                              y={itemRect.y}
-                              layoutType={type}
-                              index={dataIndex}
-                              styleOverrides={styleOverrides}
-                              layoutProvider={this.props.layoutProvider}
-                              forceNonDeterministicRendering={this.props.forceNonDeterministicRendering}
-                              isHorizontal={this.props.isHorizontal}
-                              onSizeChanged={this._onViewContainerSizeChange}
-                              childRenderer={this.props.rowRenderer}
-                              height={itemRect.height}
-                              width={itemRect.width}
-                              itemAnimator={Default.value<ItemAnimator>(this.props.itemAnimator, this._defaultItemAnimator)}
-                              extendedState={this.props.extendedState}/>
+                    dataHasChanged={this._dataHasChanged}
+                    x={itemRect.x}
+                    y={itemRect.y}
+                    layoutType={type}
+                    index={dataIndex}
+                    styleOverrides={styleOverrides}
+                    layoutProvider={this.props.layoutProvider}
+                    forceNonDeterministicRendering={this.props.forceNonDeterministicRendering}
+                    isHorizontal={this.props.isHorizontal}
+                    onSizeChanged={this._onViewContainerSizeChange}
+                    childRenderer={this.props.rowRenderer}
+                    height={itemRect.height}
+                    width={itemRect.width}
+                    itemAnimator={Default.value<ItemAnimator>(this.props.itemAnimator, this._defaultItemAnimator)}
+                    extendedState={this.props.extendedState}
+                    getViewHolderForType={this.props.getViewHolderForType} />
             );
         }
         return null;
@@ -672,4 +674,8 @@ RecyclerListView.propTypes = {
     //For all props that need to be proxied to inner/external scrollview. Put them in an object and they'll be spread
     //and passed down.
     scrollViewProps: PropTypes.object,
+    
+    //Function to receive the row type and returns a component to wrap the row children in.
+    //Useful for implementing row reordering with drag and drop.
+    getViewHolderForType: PropTypes.func,
 };

--- a/src/core/viewrenderer/BaseViewRenderer.tsx
+++ b/src/core/viewrenderer/BaseViewRenderer.tsx
@@ -26,6 +26,7 @@ export interface ViewRendererProps<T> {
     isHorizontal?: boolean;
     extendedState?: object;
     layoutProvider?: BaseLayoutProvider;
+    getViewHolderForType?: (type: string | number) => JSX.Element;
 }
 export default abstract class BaseViewRenderer<T> extends React.Component<ViewRendererProps<T>, {}> {
     protected animatorStyleOverrides: object | undefined;

--- a/src/platform/reactnative/viewrenderer/ViewRenderer.tsx
+++ b/src/platform/reactnative/viewrenderer/ViewRenderer.tsx
@@ -13,9 +13,11 @@ export default class ViewRenderer extends BaseViewRenderer<any> {
     private _dim: Dimension = { width: 0, height: 0 };
     private _viewRef: React.Component<ViewProperties, React.ComponentState> | null = null;
     public render(): JSX.Element {
+        const ViewHolder: any = this.props.getViewHolderForType ? this.props.getViewHolderForType(this.props.layoutType) : View;
+
         return this.props.forceNonDeterministicRendering ? (
-            <View ref={this._setRef}
-            onLayout={this._onLayout}
+            <ViewHolder ref={this._setRef}
+                onLayout={this._onLayout}
                 style={{
                     flexDirection: this.props.isHorizontal ? "column" : "row",
                     left: this.props.x,
@@ -25,20 +27,20 @@ export default class ViewRenderer extends BaseViewRenderer<any> {
                     ...this.animatorStyleOverrides,
                 }}>
                 {this.renderChild()}
-            </View>
+            </ViewHolder>
         ) : (
-                <View ref={this._setRef}
-                    style={{
-                        left: this.props.x,
-                        position: "absolute",
-                        top: this.props.y,
-                        height: this.props.height,
-                        width: this.props.width,
-                        ...this.props.styleOverrides,
-                        ...this.animatorStyleOverrides,
-                    }}>
-                    {this.renderChild()}
-                </View>
+            <ViewHolder ref={this._setRef}
+                style={{
+                    left: this.props.x,
+                    position: "absolute",
+                    top: this.props.y,
+                    height: this.props.height,
+                    width: this.props.width,
+                    ...this.props.styleOverrides,
+                    ...this.animatorStyleOverrides,
+                }}>
+                {this.renderChild()}
+            </ViewHolder>
             );
     }
 

--- a/src/platform/web/viewrenderer/ViewRenderer.tsx
+++ b/src/platform/web/viewrenderer/ViewRenderer.tsx
@@ -24,6 +24,7 @@ export default class ViewRenderer extends BaseViewRenderer<any> {
     }
 
     public render(): JSX.Element {
+        const ViewHolder: any = this.props.getViewHolderForType ? this.props.getViewHolderForType(this.props.layoutType) : "div";
         const style: CSSProperties = this.props.forceNonDeterministicRendering
             ? {
                 transform: this._getTransform(),
@@ -43,9 +44,9 @@ export default class ViewRenderer extends BaseViewRenderer<any> {
                 ...this.animatorStyleOverrides,
             };
         return (
-            <div ref={this._setRef} style={style}>
+            <ViewHolder ref={this._setRef} style={style}>
                 {this.renderChild()}
-            </div>
+            </ViewHolder>
         );
     }
 


### PR DESCRIPTION
Based on the discussion from https://github.com/Flipkart/recyclerlistview/issues/146#issuecomment-394588856, this implements a prop called `getViewHolderForType` that will receive the row type and return the component to wrap the row.

Typescript isn't my first language, so I'm assuming we need a better type specification than `: any`, but everything else I tried resulted in lint errors.

Testing this locally works for me, though in full disclosure, I have yet to use it to implement drag and drop.