### PR TITLE
Bug Fix: First item with 0 height

### DIFF
--- a/src/core/ViewabilityTracker.ts
+++ b/src/core/ViewabilityTracker.ts
@@ -265,10 +265,15 @@ export default class ViewabilityTracker {
         return (window.start >= startBound && window.end <= endBound);
     }
 
+    private _isItemBoundsExactlyAtWindowStart(window: Range, startBound: number, endBound: number): boolean {
+        return (endBound - startBound === 0) && window.start === startBound;
+    }
+
     private _itemIntersectsWindow(window: Range, startBound: number, endBound: number): boolean {
         return this._isItemInBounds(window, startBound) ||
             this._isItemInBounds(window, endBound) ||
-            this._isItemBoundsBeyondWindow(window, startBound, endBound);
+            this._isItemBoundsBeyondWindow(window, startBound, endBound) ||
+            this._isItemBoundsExactlyAtWindowStart(window, startBound, endBound);
     }
 
     private _itemIntersectsEngagedWindow(startBound: number, endBound: number): boolean {


### PR DESCRIPTION
When an item is of 0 height and is just on the borderline of window start. It doesn't gets rendered and is treated as out of viewport.

Fix: added check to include it in viewport