### PR TITLE
Bugfix dataprovider cloning

### DIFF
--- a/src/core/dependencies/DataProvider.ts
+++ b/src/core/dependencies/DataProvider.ts
@@ -24,6 +24,11 @@ export default class DataProvider {
             this.getStableId = (index) => index.toString();
         }
     }
+
+    public clone(): DataProvider {
+        return new DataProvider(this.rowHasChanged, this.getStableId);
+    }
+
     public getDataForIndex(index: number): any {
         return this._data[index];
     }
@@ -51,7 +56,7 @@ export default class DataProvider {
     //No need to override this one
     //If you already know the first row where rowHasChanged will be false pass it upfront to avoid loop
     public cloneWithRows(newData: any[], firstModifiedIndex?: number): DataProvider {
-        const dp = new DataProvider(this.rowHasChanged, this.getStableId);
+        const dp = this.clone();
         const newSize = newData.length;
         const iterCount = Math.min(this._size, newSize);
         if (ObjectUtil.isNullOrUndefined(firstModifiedIndex)) {

--- a/src/core/dependencies/DataProvider.ts
+++ b/src/core/dependencies/DataProvider.ts
@@ -70,7 +70,7 @@ export default class DataProvider {
         } else {
             dp._firstIndexToProcess = Math.max(Math.min(firstModifiedIndex, this._data.length), 0);
         }
-        if (dp._firstIndexToProcess !== this._data.length) {
+        if (this._data.length === 0 || dp._firstIndexToProcess !== this._data.length) {
             dp._requiresDataChangeHandling = true;
         }
         dp._data = newData;


### PR DESCRIPTION
There's two issues when using `DataProvider.cloneWithRows(items)`:

1. It is not possible to use this method on a class which extends `DataProvider`, the method will create an instance of the base class and not the extended class. This has been remedied by providing a separate `clone()` method which the subclass can re-implement. `clone()` is then called in `cloneWithRows(items)` instead of `new DataProvider`.

2. Calling `cloneWithRows(items)` on a DataProvider which has size == 0 did not set the `_requiresDataChangeHandling` flag to `true` in the clone, since the `_firstIndexToProcess` would equal the empty DataProvider length (0). Added another part to the condition to check if the DataProvider being cloned is empty.