### PR TITLE
Bugfix ensure reference to getStableId is updated`

### DIFF
--- a/src/core/VirtualRenderer.ts
+++ b/src/core/VirtualRenderer.ts
@@ -316,6 +316,10 @@ export default class VirtualRenderer {
         }
     }
 
+    public setStableIdProvider(getStableId: StableIdProvider): void {
+        this._fetchStableId = getStableId;
+    }
+
     private _getCollisionAvoidingKey(): string {
         return "#" + this._startKey++ + "_rlv_c";
     }


### PR DESCRIPTION
(This PR replaces https://github.com/Flipkart/recyclerlistview/pull/339)

This is a bugfix for the case when the DataProvider is changed, and may provide entirely different data. The VirtualRenderer needs to update its own reference to getStableId to ensure that it uses the correct IDs for the components it creates.

You can test this bug by the following steps:

1. Instantiate a RecyclerListView with a DataProvider containing 1 item.
2. Change the DataProvider to one containing 3 items
3. The RecyclerListView will crash due to trying to look up the 2 new items using the old DataProvider's getStableId function.

This solution is to update the cached function in VirtualRenderer when the DataProvider hasStableIds and has changed.