### PR TITLE
Update BinarySearch.ts

### DIFF
--- a/src/utils/BinarySearch.ts
+++ b/src/utils/BinarySearch.ts
@@ -75,7 +75,7 @@ export default class BinarySearch {
     public static findValueSmallerThanTarget(values: number[], target: number): ValueAndIndex | undefined {
         const low = 0;
         const high = values.length - 1;
-        if (target > values[high]) {
+        if (target >= values[high]) {
             return {
                 value: values[high],
                 index: high,


### PR DESCRIPTION
Motivation: When using this library I came across some strange behavior. When I was using sticky header in my list if i got my scroll exactly to the point where previous header should disappear, and the new one should stick to the top of the screen, when I changed size of the items below, the header switched to the previous without any sensible reason. This happen only to the last sticky header. 
For the [0, 14, 16] values of stickyIndices in:
var valueAndIndex = BinarySearch_1.default.findValueSmallerThanTarget(stickyIndices, smallestVisibleIndex);
i got results:
for smallestVisibleIndex == 13 I got valueAndIndex.index: 0
for smallestVisibleIndex == 14 I got valueAndIndex.index: 1
for smallestVisibleIndex == 16 I got valueAndIndex.index: 1
for smallestVisibleIndex == 17 I got valueAndIndex.index: 2