### PR TITLE
better optimizeForInsertDeleteAnimations and fix stableId collision

### DIFF
--- a/src/core/VirtualRenderer.ts
+++ b/src/core/VirtualRenderer.ts
@@ -227,7 +227,7 @@ export default class VirtualRenderer {
                 }
             } else {
                 key = getStableId(index);
-                if(this._cachedRenderStack[key]) {
+                if (this._cachedRenderStack[key]) {
                     delete this._cachedRenderStack[key];
                     key = this._getCollisionAvoidingKey();
                 }

--- a/src/core/VirtualRenderer.ts
+++ b/src/core/VirtualRenderer.ts
@@ -282,7 +282,7 @@ export default class VirtualRenderer {
                 delete this._stableIdToRenderKeyMap[key];
             }
         }
-        if(shouldOptimizeForAnimations && this._isRecyclingEnabled) {
+        if (shouldOptimizeForAnimations && this._isRecyclingEnabled) {
             this._recyclePool.clearAll();
         }
         for (const key in this._renderStack) {
@@ -307,7 +307,7 @@ export default class VirtualRenderer {
             }
         }
         Object.assign(this._renderStack, newRenderStack);
-        if(!shouldOptimizeForAnimations && this._isRecyclingEnabled) {
+        if (!shouldOptimizeForAnimations && this._isRecyclingEnabled) {
             for (const key in this._renderStack) {
                 if (this._renderStack.hasOwnProperty(key)) {
                     const index = this._renderStack[key].dataIndex;

--- a/src/core/VirtualRenderer.ts
+++ b/src/core/VirtualRenderer.ts
@@ -288,7 +288,7 @@ export default class VirtualRenderer {
                 delete this._stableIdToRenderKeyMap[key];
             }
         }
-        if (shouldOptimizeForAnimations && this._isRecyclingEnabled) {
+        if (shouldOptimizeForAnimations && this._isRecyclingEnabled && this._recyclePool) {
             this._recyclePool.clearAll();
         }
         this._cachedRenderStack = Object.assign({}, this._renderStack);

--- a/src/core/VirtualRenderer.ts
+++ b/src/core/VirtualRenderer.ts
@@ -282,7 +282,9 @@ export default class VirtualRenderer {
                 delete this._stableIdToRenderKeyMap[key];
             }
         }
-
+        if(shouldOptimizeForAnimations && this._isRecyclingEnabled) {
+            this._recyclePool.clearAll();
+        }
         for (const key in this._renderStack) {
             if (this._renderStack.hasOwnProperty(key)) {
                 const index = this._renderStack[key].dataIndex;
@@ -305,13 +307,14 @@ export default class VirtualRenderer {
             }
         }
         Object.assign(this._renderStack, newRenderStack);
-
-        for (const key in this._renderStack) {
-            if (this._renderStack.hasOwnProperty(key)) {
-                const index = this._renderStack[key].dataIndex;
-                if (!ObjectUtil.isNullOrUndefined(index) && ObjectUtil.isNullOrUndefined(this._engagedIndexes[index])) {
-                    const type = this._layoutProvider.getLayoutTypeForIndex(index);
-                    this._recyclePool.putRecycledObject(type, key);
+        if(!shouldOptimizeForAnimations && this._isRecyclingEnabled) {
+            for (const key in this._renderStack) {
+                if (this._renderStack.hasOwnProperty(key)) {
+                    const index = this._renderStack[key].dataIndex;
+                    if (!ObjectUtil.isNullOrUndefined(index) && ObjectUtil.isNullOrUndefined(this._engagedIndexes[index])) {
+                        const type = this._layoutProvider.getLayoutTypeForIndex(index);
+                        this._recyclePool.putRecycledObject(type, key);
+                    }
                 }
             }
         }

--- a/src/core/dependencies/DataProvider.ts
+++ b/src/core/dependencies/DataProvider.ts
@@ -53,7 +53,7 @@ export abstract class BaseDataProvider {
 
     //No need to override this one
     //If you already know the first row where rowHasChanged will be false pass it upfront to avoid loop
-    public cloneWithRows(newData: any[], firstModifiedIndex?: number): DataProvider {
+    public cloneWithRows(newData: any[], firstModifiedIndex?: number, optimizeForInsertAtBottomAnimation?: boolean): DataProvider {
         const dp = this.newInstance(this.rowHasChanged, this.getStableId);
         const newSize = newData.length;
         const iterCount = Math.min(this._size, newSize);
@@ -70,6 +70,10 @@ export abstract class BaseDataProvider {
         }
         if (dp._firstIndexToProcess !== this._data.length) {
             dp._requiresDataChangeHandling = true;
+        } else {
+            if (optimizeForInsertAtBottomAnimation && this._data.length < newSize) {
+                dp._requiresDataChangeHandling = true;
+            }
         }
         dp._data = newData;
         dp._size = newSize;


### PR DESCRIPTION
This PR try to prevent RLV recycler too hard.
I try to use RLV and react-native-reanimated (Transitioning.View) for cool list animation (fade in, fade out, move)
But original RLV with optimizeForInsertDeleteAnimations not help 100%
When new item with new stableId come in.
Sometimes, RLV try to recycle with old render key so animation is Transition.Change, not Transition.In
So, my core idea. every time dataSource change. I will clear recyclePool. It will prevent reuse old render key, 
new item will mount in (not update). It also help stableId collision.

DataProvider.cloneWithRows with 3rd optinal parameter optimizeForInsertAtBottomAnimation = true will try to _requiresDataChangeHandling when dataSource have something new item added to bottom of RLV (load more)
So _requiresDataChangeHandling = true will trigger VirtualRenderer.handleDataSetChange and prevent recycle items at top of RLV (Prevent top down move animation).  

Now i'm happy with RLV and react-native-reanimated and goodbye Flatlist :)