### PR TITLE
Sticky - Correcting offsetY on first compute

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recyclerlistview",
-  "version": "3.0.1-Ananya.SNAPSHOT",
+  "version": "3.0.2",
   "description": "The listview that you need and deserve. It was built for performance, uses cell recycling to achieve smooth scrolling.",
   "main": "dist/reactnative/index.js",
   "types": "dist/reactnative/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recyclerlistview",
-  "version": "3.0.1",
+  "version": "3.0.1-Ananya.SNAPSHOT",
   "description": "The listview that you need and deserve. It was built for performance, uses cell recycling to achieve smooth scrolling.",
   "main": "dist/reactnative/index.js",
   "types": "dist/reactnative/index.d.ts",

--- a/src/core/sticky/StickyFooter.tsx
+++ b/src/core/sticky/StickyFooter.tsx
@@ -59,7 +59,7 @@ export default class StickyFooter<P extends StickyObjectProps> extends StickyObj
     }
 
     protected hasReachedBoundary(offsetY: number, windowBound?: number): boolean {
-        if (windowBound) {
+        if (windowBound !== undefined) {
             const endReachedMargin = Math.round(offsetY - (windowBound));
             return endReachedMargin >= 0;
         }

--- a/src/core/sticky/StickyObject.tsx
+++ b/src/core/sticky/StickyObject.tsx
@@ -71,7 +71,7 @@ export default abstract class StickyObject<P extends StickyObjectProps> extends 
     }
 
     public componentWillReceivePropsCompat(newProps: StickyObjectProps): void {
-        this._initParams();
+        this._updateDimensionParams();
         this.calculateVisibleStickyIndex(newProps.stickyIndices, this._smallestVisibleIndex, this._largestVisibleIndex,
             this._offsetY, this._windowBound);
         this._computeLayouts(newProps.stickyIndices);
@@ -101,10 +101,10 @@ export default abstract class StickyObject<P extends StickyObjectProps> extends 
     public onVisibleIndicesChanged(all: number[]): void {
         if (this._firstCompute) {
             this.initStickyParams();
-            this._firstCompute = false;
             this._offsetY = this._getAdjustedOffsetY(this._offsetY);
+            this._firstCompute = false;
         }
-        this._initParams();
+        this._updateDimensionParams();
         this._setSmallestAndLargestVisibleIndices(all);
         this.calculateVisibleStickyIndex(this.props.stickyIndices, this._smallestVisibleIndex, this._largestVisibleIndex,
             this._offsetY, this._windowBound);
@@ -115,7 +115,7 @@ export default abstract class StickyObject<P extends StickyObjectProps> extends 
     public onScroll(offsetY: number): void {
         offsetY = this._getAdjustedOffsetY(offsetY);
         this._offsetY = offsetY;
-        this._initParams();
+        this._updateDimensionParams();
         this.boundaryProcessing(offsetY, this._windowBound);
         if (this._previousStickyIndex !== undefined) {
             if (this._previousStickyIndex * this.stickyTypeMultiplier >= this.currentStickyIndex * this.stickyTypeMultiplier) {
@@ -186,7 +186,7 @@ export default abstract class StickyObject<P extends StickyObjectProps> extends 
         }
     }
 
-    private _initParams(): void {
+    private _updateDimensionParams(): void {
         const rlvDimension: Dimension | undefined = this.props.getRLVRenderedSize();
         if (rlvDimension) {
             this._scrollableHeight = rlvDimension.height;

--- a/src/core/sticky/StickyObject.tsx
+++ b/src/core/sticky/StickyObject.tsx
@@ -102,6 +102,7 @@ export default abstract class StickyObject<P extends StickyObjectProps> extends 
         if (this._firstCompute) {
             this.initStickyParams();
             this._firstCompute = false;
+            this._offsetY = this._getAdjustedOffsetY(this._offsetY);
         }
         this._initParams();
         this._setSmallestAndLargestVisibleIndices(all);
@@ -112,9 +113,9 @@ export default abstract class StickyObject<P extends StickyObjectProps> extends 
     }
 
     public onScroll(offsetY: number): void {
-        offsetY += this.getWindowCorrection(this.props).windowShift;
-        this._initParams();
+        offsetY = this._getAdjustedOffsetY(offsetY);
         this._offsetY = offsetY;
+        this._initParams();
         this.boundaryProcessing(offsetY, this._windowBound);
         if (this._previousStickyIndex !== undefined) {
             if (this._previousStickyIndex * this.stickyTypeMultiplier >= this.currentStickyIndex * this.stickyTypeMultiplier) {
@@ -186,7 +187,6 @@ export default abstract class StickyObject<P extends StickyObjectProps> extends 
     }
 
     private _initParams(): void {
-        this.getWindowCorrection(this.props);
         const rlvDimension: Dimension | undefined = this.props.getRLVRenderedSize();
         if (rlvDimension) {
             this._scrollableHeight = rlvDimension.height;
@@ -240,5 +240,9 @@ export default abstract class StickyObject<P extends StickyObjectProps> extends 
         } else {
             return _rowRenderer(_stickyLayoutType, _stickyData, this.currentStickyIndex, _extendedState);
         }
+    }
+
+    private _getAdjustedOffsetY(offsetY: number): number {
+        return offsetY + this.getWindowCorrection(this.props).windowShift;
     }
 }


### PR DESCRIPTION
- `offsetY` is corrected with the `windowShift` attribute in `onScroll`. This also needs to be corrected on first load before the user scrolls.
- Renaming `_initParams` to `_updateDimensionParams`.