### PR TITLE
Added bring to focus functionality

### DIFF
--- a/src/core/RecyclerListView.tsx
+++ b/src/core/RecyclerListView.tsx
@@ -242,6 +242,11 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
         }
     }
 
+    /**
+     * This API is almost similar to scrollToIndex, but differs when the view is already in viewport. 
+     * Instead of bringing the view to the top of the viewport, it will calculate the overflow of the @param index 
+     * and scroll to just bring the entire view to viewport.
+     */
     public bringToFocus(index: number, animate?: boolean): void {
         const listSize = this.getRenderedSize();
         const itemLayout = this.getLayout(index);

--- a/src/core/RecyclerListView.tsx
+++ b/src/core/RecyclerListView.tsx
@@ -242,6 +242,28 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
         }
     }
 
+    public bringToFocus(index: number, animate?: boolean) {
+        const listSize = this.getRenderedSize();
+        const itemLayout = this.getLayout(index);
+        const currentScrollOffset = this.getCurrentScrollOffset();
+        const {isHorizontal} = this.props;
+        if (itemLayout) {
+            const mainAxisLayoutDimen = isHorizontal ? itemLayout.width : itemLayout.height;
+            const mainAxisLayoutPos = isHorizontal ? itemLayout.x : itemLayout.y;
+            const mainAxisListDimen = isHorizontal ? listSize.width : listSize.height;
+            const screenEndPos = mainAxisListDimen + currentScrollOffset;
+            if (mainAxisLayoutDimen > mainAxisListDimen || mainAxisLayoutPos < currentScrollOffset || mainAxisLayoutPos > screenEndPos) {
+                this.scrollToIndex(index);
+            } else {
+                const viewEndPos = mainAxisLayoutPos + mainAxisLayoutDimen;
+                if (viewEndPos > screenEndPos) {
+                    const offset = viewEndPos - screenEndPos;
+                    this.scrollToOffset(0, offset + currentScrollOffset, animate);
+                }
+            }
+        }
+    }
+
     public scrollToItem(data: any, animate?: boolean): void {
         const count = this.props.dataProvider.getSize();
         for (let i = 0; i < count; i++) {

--- a/src/core/RecyclerListView.tsx
+++ b/src/core/RecyclerListView.tsx
@@ -243,8 +243,8 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
     }
 
     /**
-     * This API is almost similar to scrollToIndex, but differs when the view is already in viewport. 
-     * Instead of bringing the view to the top of the viewport, it will calculate the overflow of the @param index 
+     * This API is almost similar to scrollToIndex, but differs when the view is already in viewport.
+     * Instead of bringing the view to the top of the viewport, it will calculate the overflow of the @param index
      * and scroll to just bring the entire view to viewport.
      */
     public bringToFocus(index: number, animate?: boolean): void {

--- a/src/core/RecyclerListView.tsx
+++ b/src/core/RecyclerListView.tsx
@@ -242,7 +242,7 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
         }
     }
 
-    public bringToFocus(index: number, animate?: boolean) {
+    public bringToFocus(index: number, animate?: boolean): void {
         const listSize = this.getRenderedSize();
         const itemLayout = this.getLayout(index);
         const currentScrollOffset = this.getCurrentScrollOffset();


### PR DESCRIPTION
This PR adds a feature to bring to focus a particular index. This API is almost similar to scrollToIndex, but differs when the view is already in viewport. Instead of bringing the view to the top of the viewport, it will calculate the overflow the the selected index and scroll to just bring the entire view to viewport. 