### PR TITLE
Making RLV render stack wait for pending offset

### DIFF
--- a/src/core/RecyclerListView.tsx
+++ b/src/core/RecyclerListView.tsx
@@ -393,7 +393,6 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
     private _processInitialOffset(): void {
         if (this._pendingScrollToOffset) {
             const offset = this._pendingScrollToOffset;
-            this._pendingScrollToOffset = null;
             if (this.props.isHorizontal) {
                 offset.y = 0;
             } else {
@@ -401,6 +400,7 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
             }
             setTimeout(() => {
                 this.scrollToOffset(offset.x, offset.y, false);
+                this._pendingScrollToOffset = null;
             }, 0);
         }
     }
@@ -524,7 +524,7 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
     }
 
     private _renderStackWhenReady = (stack: RenderStack): void => {
-        if (!this._initStateIfRequired(stack)) {
+        if (!this._initStateIfRequired(stack) && !this._pendingScrollToOffset) {
             this.setState(() => {
                 return { renderStack: stack };
             });

--- a/src/core/RecyclerListView.tsx
+++ b/src/core/RecyclerListView.tsx
@@ -147,6 +147,7 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
     };
     private _layout: Dimension = { height: 0, width: 0 };
     private _pendingScrollToOffset: Point | null = null;
+    private _pendingScrollComplete: boolean = true;
     private _tempDim: Dimension = { height: 0, width: 0 };
     private _initialOffset = 0;
     private _cachedLayouts?: Layout[];
@@ -393,6 +394,7 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
     private _processInitialOffset(): void {
         if (this._pendingScrollToOffset) {
             const offset = this._pendingScrollToOffset;
+            this._pendingScrollToOffset = null;
             if (this.props.isHorizontal) {
                 offset.y = 0;
             } else {
@@ -400,7 +402,7 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
             }
             setTimeout(() => {
                 this.scrollToOffset(offset.x, offset.y, false);
-                this._pendingScrollToOffset = null;
+                this._pendingScrollComplete = true;
             }, 0);
         }
     }
@@ -524,7 +526,7 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
     }
 
     private _renderStackWhenReady = (stack: RenderStack): void => {
-        if (!this._initStateIfRequired(stack) && !this._pendingScrollToOffset) {
+        if (!this._initStateIfRequired(stack) && this._pendingScrollComplete) {
             this.setState(() => {
                 return { renderStack: stack };
             });
@@ -556,6 +558,7 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
         if ((offset.y > 0 && contentDimension.height > this._layout.height) ||
             (offset.x > 0 && contentDimension.width > this._layout.width)) {
             this._pendingScrollToOffset = offset;
+            this._pendingScrollComplete =  false;
             if (!this._initStateIfRequired()) {
                 this.setState({});
             }

--- a/src/core/RecyclerListView.tsx
+++ b/src/core/RecyclerListView.tsx
@@ -394,19 +394,21 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
 
     private _processInitialOffset(): void {
         if (this._pendingScrollToOffset) {
-            const offset = this._pendingScrollToOffset;
-            this._pendingScrollToOffset = null;
-            if (this.props.isHorizontal) {
-                offset.y = 0;
-            } else {
-                offset.x = 0;
-            }
             setTimeout(() => {
-                this.scrollToOffset(offset.x, offset.y, false);
-                this._pendingScrollComplete = true;
-                if (this._pendingRenderStack) {
-                    this._renderStackWhenReady(this._pendingRenderStack);
-                    this._pendingRenderStack = undefined;
+                if (this._pendingScrollToOffset) {
+                    const offset = this._pendingScrollToOffset;
+                    this._pendingScrollToOffset = null;
+                    if (this.props.isHorizontal) {
+                        offset.y = 0;
+                    } else {
+                        offset.x = 0;
+                    }
+                    this.scrollToOffset(offset.x, offset.y, false);
+                    this._pendingScrollComplete = true;
+                    if (this._pendingRenderStack) {
+                        this._renderStackWhenReady(this._pendingRenderStack);
+                        this._pendingRenderStack = undefined;
+                    }
                 }
             }, 0);
         }
@@ -531,11 +533,10 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
     }
 
     private _renderStackWhenReady = (stack: RenderStack): void => {
+        // TODO: Flickers can further be reduced by setting _pendingScrollComplete in constructor
+        // rather than in _onSizeChanged -> _initTrackers
         if (!this._pendingScrollComplete) {
-            // TODO: Flickers can further be reduced by setting _pendingScrollComplete in constructor
-            // rather than in _onSizeChanged -> _initTrackers
-            if (!this._pendingRenderStack) { this._pendingRenderStack = {}; }
-            Object.assign(this._pendingRenderStack, stack);
+            this._pendingRenderStack = stack;
             return;
         }
         if (!this._initStateIfRequired(stack)) {

--- a/src/core/RecyclerListView.tsx
+++ b/src/core/RecyclerListView.tsx
@@ -147,7 +147,6 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
     };
     private _layout: Dimension = { height: 0, width: 0 };
     private _pendingScrollToOffset: Point | null = null;
-    private _pendingScrollComplete: boolean = true;
     private _pendingRenderStack?: RenderStack;
     private _tempDim: Dimension = { height: 0, width: 0 };
     private _initialOffset = 0;
@@ -404,7 +403,6 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
                         offset.x = 0;
                     }
                     this.scrollToOffset(offset.x, offset.y, false);
-                    this._pendingScrollComplete = true;
                     if (this._pendingRenderStack) {
                         this._renderStackWhenReady(this._pendingRenderStack);
                         this._pendingRenderStack = undefined;
@@ -533,9 +531,9 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
     }
 
     private _renderStackWhenReady = (stack: RenderStack): void => {
-        // TODO: Flickers can further be reduced by setting _pendingScrollComplete in constructor
+        // TODO: Flickers can further be reduced by setting _pendingScrollToOffset in constructor
         // rather than in _onSizeChanged -> _initTrackers
-        if (!this._pendingScrollComplete) {
+        if (this._pendingScrollToOffset) {
             this._pendingRenderStack = stack;
             return;
         }
@@ -571,7 +569,6 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
         if ((offset.y > 0 && contentDimension.height > this._layout.height) ||
             (offset.x > 0 && contentDimension.width > this._layout.width)) {
             this._pendingScrollToOffset = offset;
-            this._pendingScrollComplete =  false;
             if (!this._initStateIfRequired()) {
                 this.setState({});
             }

--- a/src/core/RecyclerListView.tsx
+++ b/src/core/RecyclerListView.tsx
@@ -532,6 +532,8 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
 
     private _renderStackWhenReady = (stack: RenderStack): void => {
         if (!this._pendingScrollComplete) {
+            // TODO: Flickers can further be reduced by setting _pendingScrollComplete in constructor
+            // rather than in _onSizeChanged -> _initTrackers
             if (!this._pendingRenderStack) { this._pendingRenderStack = {}; }
             Object.assign(this._pendingRenderStack, stack);
             return;


### PR DESCRIPTION
RLV renders the current stack before the scroll component is ready to scroll. In case of an `initialOffset` provided, RLV displays a gap and then scrolls to the required `initialOffset`, thus showing a slight flicker. This change waits for the scroll component to complete its scroll before rendering the stack.