### PR TITLE
Add collection as 2nd parameter to getStableId function

### DIFF
--- a/src/core/RecyclerListView.tsx
+++ b/src/core/RecyclerListView.tsx
@@ -164,7 +164,7 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
         this._virtualRenderer = new VirtualRenderer(this._renderStackWhenReady, (offset) => {
             this._pendingScrollToOffset = offset;
         }, (index) => {
-            return this.props.dataProvider.getStableId(index);
+            return this.props.dataProvider.getStableId(index, this.props.dataProvider.getAllData());
         }, !props.disableRecycling);
 
         this._windowCorrection = {

--- a/src/core/VirtualRenderer.ts
+++ b/src/core/VirtualRenderer.ts
@@ -289,7 +289,7 @@ export default class VirtualRenderer {
                 if (!ObjectUtil.isNullOrUndefined(index)) {
                     if (index <= maxIndex) {
                         const newKey = this.syncAndGetKey(
-                            index, 
+                            index,
                             (i: number) => getStableId(i, newDataProvider.getAllData()),
                             newRenderStack);
                         const newStackItem = newRenderStack[newKey];

--- a/src/core/VirtualRenderer.ts
+++ b/src/core/VirtualRenderer.ts
@@ -260,7 +260,7 @@ export default class VirtualRenderer {
                 const index = this._renderStack[key].dataIndex;
                 if (!ObjectUtil.isNullOrUndefined(index)) {
                     if (index <= maxIndex) {
-                        const stableId = getStableId(index);
+                        const stableId = getStableId(index, newDataProvider.getAllData());
                         activeStableIds[stableId] = 1;
                     }
                 }
@@ -288,14 +288,17 @@ export default class VirtualRenderer {
                 const index = this._renderStack[key].dataIndex;
                 if (!ObjectUtil.isNullOrUndefined(index)) {
                     if (index <= maxIndex) {
-                        const newKey = this.syncAndGetKey(index, getStableId, newRenderStack);
+                        const newKey = this.syncAndGetKey(
+                            index, 
+                            (i: number) => getStableId(i, newDataProvider.getAllData()),
+                            newRenderStack);
                         const newStackItem = newRenderStack[newKey];
                         if (!newStackItem) {
                             newRenderStack[newKey] = { dataIndex: index };
                         } else if (newStackItem.dataIndex !== index) {
                             const cllKey = this._getCollisionAvoidingKey();
                             newRenderStack[cllKey] = { dataIndex: index };
-                            this._stableIdToRenderKeyMap[getStableId(index)] = {
+                            this._stableIdToRenderKeyMap[getStableId(index, newDataProvider.getAllData())] = {
                                 key: cllKey, type: this._layoutProvider.getLayoutTypeForIndex(index),
                             };
                         }

--- a/src/core/dependencies/DataProvider.ts
+++ b/src/core/dependencies/DataProvider.ts
@@ -8,24 +8,24 @@ export abstract class BaseDataProvider {
     public rowHasChanged: (r1: any, r2: any) => boolean;
 
     // In JS context make sure stable id is a string
-    public getStableId: (index: number) => string;
+    public getStableId: (index: number, data: any[]) => string;
     private _firstIndexToProcess: number = 0;
     private _size: number = 0;
     private _data: any[] = [];
     private _hasStableIds = false;
     private _requiresDataChangeHandling = false;
 
-    constructor(rowHasChanged: (r1: any, r2: any) => boolean, getStableId?: (index: number) => string) {
+    constructor(rowHasChanged: (r1: any, r2: any) => boolean, getStableId?: (index: number, data: any[]) => string) {
         this.rowHasChanged = rowHasChanged;
         if (getStableId) {
             this.getStableId = getStableId;
             this._hasStableIds = true;
         } else {
-            this.getStableId = (index) => index.toString();
+            this.getStableId = (index, data) => index.toString();
         }
     }
 
-    public abstract newInstance(rowHasChanged: (r1: any, r2: any) => boolean, getStableId?: (index: number) => string): BaseDataProvider;
+    public abstract newInstance(rowHasChanged: (r1: any, r2: any) => boolean, getStableId?: (index: number, data: any[]) => string): BaseDataProvider;
 
     public getDataForIndex(index: number): any {
         return this._data[index];
@@ -78,7 +78,7 @@ export abstract class BaseDataProvider {
 }
 
 export default class DataProvider extends BaseDataProvider {
-    public newInstance(rowHasChanged: (r1: any, r2: any) => boolean, getStableId?: ((index: number) => string) | undefined): BaseDataProvider {
+    public newInstance(rowHasChanged: (r1: any, r2: any) => boolean, getStableId?: ((index: number, data: any[]) => string) | undefined): BaseDataProvider {
         return new DataProvider(rowHasChanged, getStableId);
     }
 }


### PR DESCRIPTION
Fix #460 

Currently, `getStableId` function only has `index` param, which requires to keep the collection hanging somewhere.

This PR will make `getStableId` has a signature like:
`(index:number, rows:Array) => any`

Then the `getStableId` logic could be specified just once, for example if I have an array of some objects with some ids it would be as simple as

```
dataProvider = new DataProvider(
      (r1, r2) => {
        return r1.id !== r2.id
      },
      (index, rows) => {
        return rows[index].id
      }
    )
```