### PR TITLE
Add support for bidirectional infinite scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ In case you cannot determine heights of items in advance just set `forceNonDeter
 | onVisibleIndicesChanged | No | TOnItemStatusChanged | Provides visible index; helpful in sending impression events |
 | onVisibleIndexesChanged | No | TOnItemStatusChanged | (Deprecated in 2.0 beta) Provides visible index; helpful in sending impression events |
 | renderFooter | No | () => JSX.Element \| JSX.Element[] \| null | Provide this method if you want to render a footer. Helpful in showing a loader while doing incremental loads |
+| renderHeader | No | () => JSX.Element \| JSX.Element[] \| null | Provide this method if you want to render a header. Helpful in showing a loader while doing incremental loads |
 | initialRenderIndex | No | number | Specify the initial item index you want rendering to start from. Preferred over initialOffset if both specified |
 | scrollThrottle | No | number |iOS only; Scroll throttle duration |
 | canChangeSize | No | boolean | Specify if size can change |

--- a/README.md
+++ b/README.md
@@ -88,8 +88,10 @@ In case you cannot determine heights of items in advance just set `forceNonDeter
 | onScroll | No | rawEvent: ScrollEvent, offsetX: number, offsetY: number) => void | On scroll callback function that executes as a user scrolls |
 | onRecreate | No | (params: OnRecreateParams) => void | callback function that gets executed when recreating the recycler view from context provider |
 | externalScrollView | No | { new (props: ScrollViewDefaultProps): BaseScrollView } | Use this to pass your on implementation of BaseScrollView |
-| onEndReached | No | () => void | Callback function executed when the end of the view is hit (minus onEndThreshold if defined) |
+| onEndReached | No | () => void | Callback function executed when the end of the view is hit (minus onEndReachedThreshold if defined) |
 | onEndReachedThreshold | No | number | Specify how many pixels in advance for the onEndReached callback |
+| onStartReached | No | () => void | Callback function executed when the start of the view is hit (plus onStartReachedThreshold if defined) |
+| onStartReachedThreshold | No | number | Specify how many pixels in advance for the onStartReached callback |
 | onVisibleIndicesChanged | No | TOnItemStatusChanged | Provides visible index; helpful in sending impression events |
 | onVisibleIndexesChanged | No | TOnItemStatusChanged | (Deprecated in 2.0 beta) Provides visible index; helpful in sending impression events |
 | renderFooter | No | () => JSX.Element \| JSX.Element[] \| null | Provide this method if you want to render a footer. Helpful in showing a loader while doing incremental loads |

--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
     "react-native": ">= 0.30.0"
   },
   "devDependencies": {
-    "@types/lodash.debounce": "4.0.3",
+    "@types/lodash.debounce": "4.0.6",
     "@types/prop-types": "15.5.2",
-    "@types/react-native": "0.49.5",
-    "@types/react": "16.4.7",
+    "@types/react": "17.0.2",
+    "@types/react-native": "0.65.0",
     "file-directives": "1.4.6",
     "tslint": "5.11.0",
     "typescript": "3.3.1"

--- a/scripts/publish-local.sh
+++ b/scripts/publish-local.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-TARGET=$"/Users/roryabraham/RecyclerListViewExample/node_modules/recyclerlistview/dist" #target-path
+TARGET=$"/Users/talha.naqvi/Documents/Work/RLV-Demo/node_modules/recyclerlistview/dist" #target-path
 
 npm run build
 

--- a/scripts/publish-local.sh
+++ b/scripts/publish-local.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-TARGET=$"/Users/talha.naqvi/Documents/Work/RLV-Demo/node_modules/recyclerlistview/dist" #target-path
+TARGET=$"/Users/roryabraham/RecyclerListViewExample/node_modules/recyclerlistview/dist" #target-path
 
 npm run build
 

--- a/src/core/RecyclerListView.tsx
+++ b/src/core/RecyclerListView.tsx
@@ -526,8 +526,8 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
         }
         const hasHeightChanged = this._layout.height !== layout.height;
         const hasWidthChanged = this._layout.width !== layout.width;
-        this._layout.height = layout.height;
-        this._layout.width = layout.width;
+        this._layout.height = Math.round(layout.height);
+        this._layout.width = Math.round(layout.width);
         if (layout.height === 0 || layout.width === 0) {
             throw new CustomError(RecyclerListViewExceptions.layoutException);
         }

--- a/src/core/RecyclerListView.tsx
+++ b/src/core/RecyclerListView.tsx
@@ -92,6 +92,7 @@ export interface RecyclerListViewProps {
     onVisibleIndexesChanged?: TOnItemStatusChanged;
     onVisibleIndicesChanged?: TOnItemStatusChanged;
     renderFooter?: () => JSX.Element | JSX.Element[] | null;
+    renderHeader?: () => JSX.Element | JSX.Element[] | null;
     externalScrollView?: { new(props: ScrollViewDefaultProps): BaseScrollView };
     layoutSize?: Dimension;
     initialOffset?: number;
@@ -765,6 +766,9 @@ RecyclerListView.propTypes = {
 
     //Provides visible index, helpful in sending impression events etc, onVisibleIndicesChanged(all, now, notNow)
     onVisibleIndicesChanged: PropTypes.func,
+
+    // Provide this method if you want to render a header. Helpful in showing a loading while doing incremental loads.
+    renderHeader: PropTypes.func,
 
     //Provide this method if you want to render a footer. Helpful in showing a loader while doing incremental loads.
     renderFooter: PropTypes.func,

--- a/src/core/RecyclerListView.tsx
+++ b/src/core/RecyclerListView.tsx
@@ -382,6 +382,7 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
                 {...this.props.scrollViewProps}
                 onScroll={this._onScroll}
                 onSizeChanged={this._onSizeChanged}
+                onWindowResize={this._processOnEdgeReached}
                 contentHeight={this._initComplete ? this._virtualRenderer.getLayoutDimension().height : 0}
                 contentWidth={this._initComplete ? this._virtualRenderer.getLayoutDimension().width : 0}
                 renderAheadOffset={this.getCurrentRenderAheadOffset()}>
@@ -690,7 +691,7 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
         this._processOnEdgeReached();
     }
 
-    private _processOnEdgeReached(): void {
+    private _processOnEdgeReached = (): void => {
         if (!this._onEdgeReachedCalled && this._virtualRenderer && (this.props.onEndReached || this.props.onStartReached)) {
             const layout = this._virtualRenderer.getLayoutDimension();
             const viewabilityTracker = this._virtualRenderer.getViewabilityTracker();

--- a/src/core/RecyclerListView.tsx
+++ b/src/core/RecyclerListView.tsx
@@ -469,8 +469,8 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
                 layoutManager.relayoutFromIndex(newProps.dataProvider.getFirstIndexToProcessInternal(), newProps.dataProvider.getSize());
                 const virtualLayoutDimensionsAfterUpdate: Dimension = layoutManager.getContentDimension();
                 const viewabilityTracker: ViewabilityTracker | null = this._virtualRenderer.getViewabilityTracker();
-                // NOTE: This works for most cases, but relies on an assumption that any items loaded onStartReached
-                //       were prepended prepended to the dataset (not inserted at the end or middle somewhere).
+                // NOTE: This works for most cases, but relies on an assumption that any items loaded during the onStartReached callback
+                //       were prepended to the dataset (not inserted at the end or middle somewhere).
                 if (viewabilityTracker && onStartReachedCalled) {
                     // Adjust offset for prepended items
                     const previousOffset: number = viewabilityTracker.getLastOffset();

--- a/src/core/RecyclerListView.tsx
+++ b/src/core/RecyclerListView.tsx
@@ -382,7 +382,7 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
                 {...this.props.scrollViewProps}
                 onScroll={this._onScroll}
                 onSizeChanged={this._onSizeChanged}
-                onWindowResize={this._processOnEdgeReached}
+                onWindowResize={this._onWindowResize}
                 contentHeight={this._initComplete ? this._virtualRenderer.getLayoutDimension().height : 0}
                 contentWidth={this._initComplete ? this._virtualRenderer.getLayoutDimension().width : 0}
                 renderAheadOffset={this.getCurrentRenderAheadOffset()}>
@@ -521,6 +521,11 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
                 this._refreshViewability();
             }
         }
+    }
+
+    private _onWindowResize = (layout: Dimension): void => {
+        this._layout = layout;
+        this._processOnEdgeReached();
     }
 
     private _initStateIfRequired(stack?: RenderStack): boolean {

--- a/src/core/RecyclerListView.tsx
+++ b/src/core/RecyclerListView.tsx
@@ -469,11 +469,8 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
                 layoutManager.relayoutFromIndex(newProps.dataProvider.getFirstIndexToProcessInternal(), newProps.dataProvider.getSize());
                 const virtualLayoutDimensionsAfterUpdate: Dimension = layoutManager.getContentDimension();
                 const viewabilityTracker: ViewabilityTracker | null = this._virtualRenderer.getViewabilityTracker();
-                // TODO:
-                //    This works for us (probably most cases) but relies on an assumption that onStartReachedCalled
-                //       loaded more items and prepended them to the dataset.
-                //    Would be more robust to somehow check if new items were inserted to the layoutManager._layouts,
-                //       and adjust the offset based on where those items were inserted.
+                // NOTE: This works for most cases, but relies on an assumption that any items loaded onStartReached
+                //       were prepended prepended to the dataset (not inserted at the end or middle somewhere).
                 if (viewabilityTracker && onStartReachedCalled) {
                     // Adjust offset for prepended items
                     const previousOffset: number = viewabilityTracker.getLastOffset();
@@ -485,17 +482,11 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
                     this._virtualRenderer.updateOffset(
                         offsetX,
                         offsetY,
-                        false,
+                        true,
                         this._getWindowCorrection(offsetX, offsetY, this.props),
                     );
                 }
-                // FIXME: maybe need to use this._virtualRenderer.forceRefreshWithOffset ?
-                // FIXME: latest change has three symptoms:
-                //   1. Causes immediate `onStartReached`
-                //   2. ~~Causes every `onEndReached` to trigger twice~~ This is fixed by adjusting the offset only if onStartReachedCalled
-                //   3. After `onStartReached`, the scroll jumps to the top, but doesn't reload again.
-                //      Needs to not jump and have some stuff displaying off-screen
-                this._virtualRenderer.refresh();
+                this._virtualRenderer.refresh(onStartReachedCalled);
             }
         } else if (forceFullRender) {
             const layoutManager = this._virtualRenderer.getLayoutManager();

--- a/src/core/RecyclerListView.tsx
+++ b/src/core/RecyclerListView.tsx
@@ -382,7 +382,7 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
                 {...this.props.scrollViewProps}
                 onScroll={this._onScroll}
                 onSizeChanged={this._onSizeChanged}
-                onWindowResize={this._onWindowResize}
+                onWindowResize={this._processOnEdgeReached}
                 contentHeight={this._initComplete ? this._virtualRenderer.getLayoutDimension().height : 0}
                 contentWidth={this._initComplete ? this._virtualRenderer.getLayoutDimension().width : 0}
                 renderAheadOffset={this.getCurrentRenderAheadOffset()}>
@@ -521,11 +521,6 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
                 this._refreshViewability();
             }
         }
-    }
-
-    private _onWindowResize = (layout: Dimension): void => {
-        this._layout = layout;
-        this._processOnEdgeReached();
     }
 
     private _initStateIfRequired(stack?: RenderStack): boolean {
@@ -698,10 +693,10 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
 
     private _processOnEdgeReached = (): void => {
         if (!this._onEdgeReachedCalled && this._virtualRenderer && (this.props.onEndReached || this.props.onStartReached)) {
-            const layout = this._virtualRenderer.getLayoutDimension();
+            const virtualLayout = this._virtualRenderer.getLayoutDimension();
             const viewabilityTracker = this._virtualRenderer.getViewabilityTracker();
             if (viewabilityTracker) {
-                const windowBound = this.props.isHorizontal ? layout.width - this._layout.width : layout.height - this._layout.height;
+                const windowBound = this.props.isHorizontal ? virtualLayout.width - this._layout.width : virtualLayout.height - this._layout.height;
                 const lastOffset = viewabilityTracker.getLastOffset();
                 const isWithinEndThreshold = windowBound - lastOffset <= Default.value<number>(this.props.onEndReachedThreshold, 0);
                 const isWithinStartThreshold = lastOffset <= Default.value<number>(this.props.onStartReachedThreshold, 0);

--- a/src/core/ViewabilityTracker.ts
+++ b/src/core/ViewabilityTracker.ts
@@ -307,21 +307,11 @@ export default class ViewabilityTracker {
         const startOffset = offset + startCorrection;
         const endOffset = (offset + this._windowBound) + endCorrection;
 
-        // tslint:disable-next-line:no-console
-        console.log("Engaged window before update:", this._engagedWindow);
-        // tslint:disable-next-line:no-console
-        console.log("Visible window before update:", this._visibleWindow);
-
         this._engagedWindow.start = Math.max(0, startOffset - this._renderAheadOffset);
         this._engagedWindow.end = endOffset + this._renderAheadOffset;
 
         this._visibleWindow.start = startOffset;
         this._visibleWindow.end = endOffset;
-
-        // tslint:disable-next-line:no-console
-        console.log("Engaged window after update:", this._engagedWindow);
-        // tslint:disable-next-line:no-console
-        console.log("Visible window after update:", this._visibleWindow);
     }
 
     //TODO:Talha optimize this

--- a/src/core/ViewabilityTracker.ts
+++ b/src/core/ViewabilityTracker.ts
@@ -93,7 +93,7 @@ export default class ViewabilityTracker {
         }
 
         if (this._currentOffset !== correctedOffset) {
-            this._currentOffset = correctedOffset;
+            this._currentOffset = Math.round(correctedOffset);
             this._updateTrackingWindows(offset, windowCorrection);
             let startIndex = 0;
             if (this._visibleIndexes.length > 0) {
@@ -169,7 +169,7 @@ export default class ViewabilityTracker {
     }
 
     private _doInitialFit(offset: number, windowCorrection: WindowCorrection): void {
-        offset = Math.min(this._maxOffset, Math.max(0, offset));
+        offset = Math.round(Math.min(this._maxOffset, Math.max(0, offset)));
         this._updateTrackingWindows(offset, windowCorrection);
         const firstVisibleIndex = this._findFirstVisibleIndexOptimally();
         this._fitAndUpdate(firstVisibleIndex);

--- a/src/core/ViewabilityTracker.ts
+++ b/src/core/ViewabilityTracker.ts
@@ -74,10 +74,9 @@ export default class ViewabilityTracker {
         this._windowBound = isHorizontal ? dimension.width : dimension.height;
     }
 
-    public forceRefresh(): boolean {
-        const shouldForceScroll = this._currentOffset >= (this._maxOffset - this._windowBound);
+    public forceRefresh(shouldForceScroll: boolean = false): boolean {
         this.forceRefreshWithOffset(this._currentOffset);
-        return shouldForceScroll;
+        return shouldForceScroll || this._currentOffset >= (this._maxOffset - this._windowBound);
     }
 
     public forceRefreshWithOffset(offset: number): void {

--- a/src/core/ViewabilityTracker.ts
+++ b/src/core/ViewabilityTracker.ts
@@ -303,16 +303,26 @@ export default class ViewabilityTracker {
 
     private _updateTrackingWindows(offset: number, correction: WindowCorrection): void {
         const startCorrection = correction.windowShift + correction.startCorrection;
-        const bottomCorrection = correction.windowShift + correction.endCorrection;
+        const endCorrection = correction.windowShift + correction.endCorrection;
 
         const startOffset = offset + startCorrection;
-        const endOffset = (offset + this._windowBound) + bottomCorrection;
+        const endOffset = (offset + this._windowBound) + endCorrection;
+
+        // tslint:disable-next-line:no-console
+        console.log("Engaged window before update:", this._engagedWindow);
+        // tslint:disable-next-line:no-console
+        console.log("Visible window before update:", this._visibleWindow);
 
         this._engagedWindow.start = Math.max(0, startOffset - this._renderAheadOffset);
         this._engagedWindow.end = endOffset + this._renderAheadOffset;
 
         this._visibleWindow.start = startOffset;
         this._visibleWindow.end = endOffset;
+
+        // tslint:disable-next-line:no-console
+        console.log("Engaged window after update:", this._engagedWindow);
+        // tslint:disable-next-line:no-console
+        console.log("Visible window after update:", this._visibleWindow);
     }
 
     //TODO:Talha optimize this

--- a/src/core/VirtualRenderer.ts
+++ b/src/core/VirtualRenderer.ts
@@ -150,10 +150,10 @@ export default class VirtualRenderer {
         }
     }
 
-    public refresh(): void {
+    public refresh(shouldForceScroll: boolean = false): void {
         if (this._viewabilityTracker) {
             this._prepareViewabilityTracker();
-            if (this._viewabilityTracker.forceRefresh()) {
+            if (this._viewabilityTracker.forceRefresh(shouldForceScroll)) {
                 if (this._params && this._params.isHorizontal) {
                     this._scrollOnNextUpdate({ x: this._viewabilityTracker.getLastActualOffset(), y: 0 });
                 } else {

--- a/src/core/dependencies/DataProvider.ts
+++ b/src/core/dependencies/DataProvider.ts
@@ -58,7 +58,6 @@ export abstract class BaseDataProvider {
 
     //No need to override this one`
     //If you already know the first row where rowHasChanged will be false pass it upfront to avoid loop
-    // TODO: Optimize this with lastModifiedIndex, _lastIndexToProcess, etc...
     public cloneWithRows(newData: any[], firstModifiedIndex: number = 0, lastModifiedIndex?: number): DataProvider {
         const dp = this.newInstance(this.rowHasChanged, this.getStableId);
         const newSize = newData.length;

--- a/src/core/layoutmanager/LayoutManager.ts
+++ b/src/core/layoutmanager/LayoutManager.ts
@@ -18,7 +18,7 @@ export abstract class LayoutManager {
         }
     }
 
-    //You can ovveride this incase you want to override style in some cases e.g, say you want to enfore width but not height
+    //You can override this in case you want to override style in some cases e.g, say you want to enforce width but not height
     public getStyleOverridesForIndex(index: number): object | undefined {
         return undefined;
     }

--- a/src/core/scrollcomponent/BaseScrollComponent.tsx
+++ b/src/core/scrollcomponent/BaseScrollComponent.tsx
@@ -11,6 +11,7 @@ export interface ScrollComponentProps {
     canChangeSize?: boolean;
     externalScrollView?: { new(props: ScrollViewDefaultProps): BaseScrollView };
     isHorizontal?: boolean;
+    renderHeader?: () => JSX.Element | JSX.Element[] | null;
     renderFooter?: () => JSX.Element | JSX.Element[] | null;
     scrollThrottle?: number;
     useWindowScroll?: boolean;

--- a/src/core/scrollcomponent/BaseScrollComponent.tsx
+++ b/src/core/scrollcomponent/BaseScrollComponent.tsx
@@ -4,6 +4,7 @@ import BaseScrollView, { ScrollEvent, ScrollViewDefaultProps } from "./BaseScrol
 
 export interface ScrollComponentProps {
     onSizeChanged: (dimensions: Dimension) => void;
+    onWindowResize: (dimensions: Dimension) => void;
     onScroll: (offsetX: number, offsetY: number, rawEvent: ScrollEvent) => void;
     contentHeight: number;
     contentWidth: number;

--- a/src/core/sticky/StickyFooter.tsx
+++ b/src/core/sticky/StickyFooter.tsx
@@ -36,13 +36,13 @@ export default class StickyFooter<P extends StickyFooterProps> extends StickyObj
         if (stickyIndices && largestVisibleIndex) {
             this.bounceScrolling = this.hasReachedBoundary(offsetY, windowBound);
             if (largestVisibleIndex > stickyIndices[stickyIndices.length - 1] || this.bounceScrolling) {
-                this.stickyVisiblity = false;
+                this.stickyVisibility = false;
                 //This is needed only in when the window is non-scrollable.
                 if (this.props.alwaysStickyFooter && offsetY === 0) {
-                    this.stickyVisiblity = true;
+                    this.stickyVisibility = true;
                 }
             } else {
-                this.stickyVisiblity = true;
+                this.stickyVisibility = true;
                 const valueAndIndex: ValueAndIndex | undefined = BinarySearch.findValueLargerThanTarget(stickyIndices, largestVisibleIndex);
                 if (valueAndIndex) {
                     this.currentIndex = valueAndIndex.index;

--- a/src/core/sticky/StickyHeader.tsx
+++ b/src/core/sticky/StickyHeader.tsx
@@ -35,9 +35,9 @@ export default class StickyHeader<P extends StickyObjectProps> extends StickyObj
         if (stickyIndices && smallestVisibleIndex !== undefined) {
             this.bounceScrolling = this.hasReachedBoundary(offsetY, windowBound);
             if (smallestVisibleIndex < stickyIndices[0] || this.bounceScrolling) {
-                this.stickyVisiblity = false;
+                this.stickyVisibility = false;
             } else {
-                this.stickyVisiblity = true;
+                this.stickyVisibility = true;
                 const valueAndIndex: ValueAndIndex | undefined = BinarySearch.findValueSmallerThanTarget(stickyIndices, smallestVisibleIndex);
                 if (valueAndIndex) {
                     this.currentIndex = valueAndIndex.index;

--- a/src/core/sticky/StickyObject.tsx
+++ b/src/core/sticky/StickyObject.tsx
@@ -33,7 +33,7 @@ export default abstract class StickyObject<P extends StickyObjectProps> extends 
 
     protected stickyType: StickyType = StickyType.HEADER;
     protected stickyTypeMultiplier: number = 1;
-    protected stickyVisiblity: boolean = false;
+    protected stickyVisibility: boolean = false;
     protected containerPosition: StyleProp<ViewStyle>;
     protected currentIndex: number = 0;
     protected currentStickyIndex: number = 0;
@@ -66,7 +66,7 @@ export default abstract class StickyObject<P extends StickyObjectProps> extends 
         startCorrection: 0, endCorrection: 0, windowShift: 0,
     };
 
-    constructor(props: P, context?: any) {
+    protected constructor(props: P, context?: any) {
         super(props, context);
     }
 
@@ -75,18 +75,28 @@ export default abstract class StickyObject<P extends StickyObjectProps> extends 
         this.calculateVisibleStickyIndex(newProps.stickyIndices, this._smallestVisibleIndex, this._largestVisibleIndex,
             this._offsetY, this._windowBound);
         this._computeLayouts(newProps.stickyIndices);
-        this.stickyViewVisible(this.stickyVisiblity, false);
+        this.stickyViewVisible(this.stickyVisibility, false);
     }
 
     public renderCompat(): JSX.Element | null {
         // Add the container style if renderContainer is undefined
-
-        const containerStyle = [{ transform: [{ translateY: this._stickyViewOffset }] },
-            (!this.props.renderContainer && [{ position: "absolute", width: this._scrollableWidth }, this.containerPosition])];
+        let containerStyle: Animated.Animated = { transform: [{ translateY: this._stickyViewOffset }] };
+        if (!this.props.renderContainer) {
+            containerStyle = {
+                ...containerStyle,
+                ...[
+                    {
+                        position: "absolute",
+                        width: this._scrollableWidth,
+                    },
+                    this.containerPosition,
+                ],
+            };
+        }
 
         const content = (
             <Animated.View style={containerStyle}>
-                {this.stickyVisiblity ? this._renderSticky() : null}
+                {this.stickyVisibility ? this._renderSticky() : null}
             </Animated.View>
         );
 
@@ -109,7 +119,7 @@ export default abstract class StickyObject<P extends StickyObjectProps> extends 
         this.calculateVisibleStickyIndex(this.props.stickyIndices, this._smallestVisibleIndex, this._largestVisibleIndex,
             this._offsetY, this._windowBound);
         this._computeLayouts();
-        this.stickyViewVisible(this.stickyVisiblity);
+        this.stickyViewVisible(this.stickyVisibility);
     }
 
     public onScroll(offsetY: number): void {
@@ -164,7 +174,7 @@ export default abstract class StickyObject<P extends StickyObjectProps> extends 
     protected abstract getScrollY(offsetY: number, scrollableHeight?: number): number | undefined;
 
     protected stickyViewVisible(_visible: boolean, shouldTriggerRender: boolean = true): void {
-        this.stickyVisiblity = _visible;
+        this.stickyVisibility = _visible;
         if (shouldTriggerRender) {
             this.setState({});
         }

--- a/src/platform/reactnative/scrollcomponent/ScrollComponent.tsx
+++ b/src/platform/reactnative/scrollcomponent/ScrollComponent.tsx
@@ -90,6 +90,7 @@ export default class ScrollComponent extends BaseScrollComponent {
         //     contentWidth,
         //     externalScrollView,
         //     canChangeSize,
+        //     renderHeader,
         //     renderFooter,
         //     isHorizontal,
         //     scrollThrottle,
@@ -105,8 +106,9 @@ export default class ScrollComponent extends BaseScrollComponent {
                 onScroll={this._onScroll}
                 onLayout={(!this._isSizeChangedCalledOnce || this.props.canChangeSize) ? this._onLayout : this.props.onLayout}>
                 <View style={{ flexDirection: this.props.isHorizontal ? "row" : "column" }}>
+                    {this.props.renderHeader && this.props.renderHeader()}
                     {renderContentContainer(contentContainerProps, this.props.children)}
-                    {this.props.renderFooter ? this.props.renderFooter() : null}
+                    {this.props.renderFooter && this.props.renderFooter()}
                 </View>
             </Scroller>
         );

--- a/src/platform/reactnative/scrollcomponent/ScrollComponent.tsx
+++ b/src/platform/reactnative/scrollcomponent/ScrollComponent.tsx
@@ -10,6 +10,8 @@ import {
 } from "react-native";
 import BaseScrollComponent, { ScrollComponentProps } from "../../../core/scrollcomponent/BaseScrollComponent";
 import TSCast from "../../../utils/TSCast";
+import debounce = require("lodash.debounce");
+
 /***
  * The responsibility of a scroll component is to report its size, scroll events and provide a way to scroll to a given offset.
  * RecyclerListView works on top of this interface and doesn't care about the implementation. To support web we only had to provide
@@ -49,12 +51,12 @@ export default class ScrollComponent extends BaseScrollComponent {
     }
 
     public componentDidMount(): void {
-        this._dimensionsChangeSubscription = Dimensions.addEventListener("change", ({window}) => {
+        this._dimensionsChangeSubscription = Dimensions.addEventListener("change", debounce(({window}) => {
             this.props.onWindowResize({
                 width: window.width,
                 height: window.height,
             });
-        });
+        }, 100));
     }
 
     public componentWillUnmount(): void {

--- a/src/platform/web/scrollcomponent/ScrollComponent.tsx
+++ b/src/platform/web/scrollcomponent/ScrollComponent.tsx
@@ -49,6 +49,11 @@ export default class ScrollComponent extends BaseScrollComponent {
 
     public render(): JSX.Element {
         const Scroller = this.props.externalScrollView as any; //TSI
+        const headerFooterWrapperStyle: React.CSSProperties | undefined = this.props.isHorizontal ? {
+            left: this.props.contentWidth,
+            position: "absolute",
+            top: 0,
+        } : undefined;
         return (
             <Scroller ref={(scrollView: BaseScrollView) => this._scrollViewRef = scrollView as (BaseScrollView | null)}
                 {...this.props}
@@ -56,19 +61,22 @@ export default class ScrollComponent extends BaseScrollComponent {
                 onScroll={this._onScroll}
                 onSizeChanged={this._onSizeChanged}>
 
+                {this.props.renderHeader && (
+                    <div style={headerFooterWrapperStyle}>
+                        {this.props.renderHeader()}
+                    </div>
+                )}
                 <div style={{
                     height: this.props.contentHeight,
                     width: this.props.contentWidth,
                 }}>
                     {this.props.children}
                 </div>
-                {this.props.renderFooter ? <div style={this.props.isHorizontal ? {
-                    left: this.props.contentWidth,
-                    position: "absolute",
-                    top: 0,
-                } : undefined}>
-                    {this.props.renderFooter()}
-                </div> : null}
+                {this.props.renderFooter && (
+                    <div style={headerFooterWrapperStyle}>
+                        {this.props.renderFooter()}
+                    </div>
+                )}
             </Scroller>
         );
     }

--- a/src/platform/web/scrollcomponent/ScrollComponent.tsx
+++ b/src/platform/web/scrollcomponent/ScrollComponent.tsx
@@ -3,6 +3,8 @@ import { Dimension } from "../../../core/dependencies/LayoutProvider";
 import BaseScrollComponent, { ScrollComponentProps } from "../../../core/scrollcomponent/BaseScrollComponent";
 import BaseScrollView, { ScrollEvent } from "../../../core/scrollcomponent/BaseScrollView";
 import ScrollViewer from "./ScrollViewer";
+import debounce = require("lodash.debounce");
+
 /***
  * The responsibility of a scroll component is to report its size, scroll events and provide a way to scroll to a given offset.
  * RecyclerListView works on top of this interface and doesn't care about the implementation. To support web we only had to provide
@@ -21,11 +23,22 @@ export default class ScrollComponent extends BaseScrollComponent {
     private _height: number;
     private _width: number;
     private _scrollViewRef: BaseScrollView | null = null;
+    // tslint:disable-next-line:ban-types - DebouncedFunc type is not exported from lodash
+    private readonly _debouncedOnWindowResize: any;
 
     constructor(args: ScrollComponentProps) {
         super(args);
         this._height = 0;
         this._width = 0;
+        this._debouncedOnWindowResize = debounce(this._onWindowResize, 100);
+    }
+
+    public componentDidMount(): void {
+        window.addEventListener("resize", this._debouncedOnWindowResize);
+    }
+
+    public componentWillUnmount(): void {
+        window.removeEventListener("resize", this._debouncedOnWindowResize);
     }
 
     public scrollTo(x: number, y: number, animated: boolean): void {
@@ -67,6 +80,15 @@ export default class ScrollComponent extends BaseScrollComponent {
     private _onSizeChanged = (event: Dimension): void => {
         if (this.props.onSizeChanged) {
             this.props.onSizeChanged(event);
+        }
+    }
+
+    private _onWindowResize = (): void => {
+        if (this.props.onWindowResize) {
+            this.props.onWindowResize({
+                width: window.innerWidth,
+                height: window.innerHeight,
+            });
         }
     }
 }


### PR DESCRIPTION
Hi @naqvitalha 👋 

Thanks for all your hard work on this repo so far! I'm exploring the possibility of integrating this repo into [Expensify](https://github.com/Expensify/App), and one of our requirements is an infinite bidirectional scrolling list, and I hope that we can work together to bring this desperately-needed functionality to the React Native community.

So this pull request fixes the following issues:

1. https://github.com/Flipkart/recyclerlistview/issues/613
2. https://github.com/Flipkart/recyclerlistview/issues/648
3. A third issue on Android where `onEndReached` would not be called unless an `onEndReachedThreshold` is provided.

### iOS
https://user-images.githubusercontent.com/47436092/134264144-9c74f705-eb0f-4b48-bb3b-68aee8612905.mov

### Web
https://user-images.githubusercontent.com/47436092/134263490-2b9621b2-4dbc-44ff-9f3d-7eed069c51f8.mov

### Android
https://user-images.githubusercontent.com/47436092/134263711-2bdb8a0c-fc96-48c3-a9a0-9bdfb74fba8b.mov