### PR TITLE
Change scrollViewProps type

### DIFF
--- a/src/core/RecyclerListView.tsx
+++ b/src/core/RecyclerListView.tsx
@@ -41,7 +41,7 @@ import { ComponentCompat } from "../utils/ComponentCompat";
 import ScrollComponent from "../platform/reactnative/scrollcomponent/ScrollComponent";
 import ViewRenderer from "../platform/reactnative/viewrenderer/ViewRenderer";
 import { DefaultJSItemAnimator as DefaultItemAnimator } from "../platform/reactnative/itemanimators/defaultjsanimator/DefaultJSItemAnimator";
-import { Platform } from "react-native";
+import { Platform, ScrollViewProps, ViewProps } from "react-native";
 const IS_WEB = !Platform || Platform.OS === "web";
 //#endif
 
@@ -107,7 +107,12 @@ export interface RecyclerListViewProps {
     renderContentContainer?: (props?: object, children?: React.ReactNode) => React.ReactNode | null;
     //For all props that need to be proxied to inner/external scrollview. Put them in an object and they'll be spread
     //and passed down. For better typescript support.
+    //#if [REACT-NATIVE]
+    scrollViewProps?: Omit<ScrollViewProps, keyof ViewProps | keyof RecyclerListViewProps>;
+    //#endif
+    //#if [WEB]
     scrollViewProps?: object;
+    //#endif
     applyWindowCorrection?: (offsetX: number, offsetY: number, windowCorrection: WindowCorrection) => void;
     onItemLayout?: (index: number) => void;
 }


### PR DESCRIPTION
Change `scrollViewProps` type for better Typescript support.
```typescript
export interface RecyclerListViewProps {
  ...
  // from
  scrollViewProps?: object;
  // to
  scrollViewProps?: Omit<ScrollViewProps, keyof ViewProps | keyof RecyclerListViewProps>;
}
```