### PR TITLE
Undefined index while rendering sticky

### DIFF
--- a/src/core/sticky/StickyObject.tsx
+++ b/src/core/sticky/StickyObject.tsx
@@ -230,7 +230,7 @@ export default abstract class StickyObject<P extends StickyObjectProps> extends 
     }
 
     private _renderSticky(): JSX.Element | JSX.Element[] | null {
-        if(this.currentStickyIndex !== undefined) {
+        if (this.currentStickyIndex !== undefined) {
             const _stickyData: any = this.props.getDataForIndex(this.currentStickyIndex);
             const _stickyLayoutType: string | number = this.props.getLayoutTypeForIndex(this.currentStickyIndex);
             const _extendedState: object | undefined = this.props.getExtendedState();

--- a/src/core/sticky/StickyObject.tsx
+++ b/src/core/sticky/StickyObject.tsx
@@ -230,16 +230,19 @@ export default abstract class StickyObject<P extends StickyObjectProps> extends 
     }
 
     private _renderSticky(): JSX.Element | JSX.Element[] | null {
-        const _stickyData: any = this.props.getDataForIndex(this.currentStickyIndex);
-        const _stickyLayoutType: string | number = this.props.getLayoutTypeForIndex(this.currentStickyIndex);
-        const _extendedState: object | undefined = this.props.getExtendedState();
-        const _rowRenderer: ((type: string | number, data: any, index: number, extendedState?: object)
-            => JSX.Element | JSX.Element[] | null) = this.props.getRowRenderer();
-        if (this.props.overrideRowRenderer) {
-            return this.props.overrideRowRenderer(_stickyLayoutType, _stickyData, this.currentStickyIndex, _extendedState);
-        } else {
-            return _rowRenderer(_stickyLayoutType, _stickyData, this.currentStickyIndex, _extendedState);
+        if(this.currentStickyIndex !== undefined) {
+            const _stickyData: any = this.props.getDataForIndex(this.currentStickyIndex);
+            const _stickyLayoutType: string | number = this.props.getLayoutTypeForIndex(this.currentStickyIndex);
+            const _extendedState: object | undefined = this.props.getExtendedState();
+            const _rowRenderer: ((type: string | number, data: any, index: number, extendedState?: object)
+                => JSX.Element | JSX.Element[] | null) = this.props.getRowRenderer();
+            if (this.props.overrideRowRenderer) {
+                return this.props.overrideRowRenderer(_stickyLayoutType, _stickyData, this.currentStickyIndex, _extendedState);
+            } else {
+                return _rowRenderer(_stickyLayoutType, _stickyData, this.currentStickyIndex, _extendedState);
+            }
         }
+        return null;
     }
 
     private _getAdjustedOffsetY(offsetY: number): number {


### PR DESCRIPTION
`currentStickyIndex` had undefined checks in the code even though it's type doesn't include it. I'm seeing cases in Shopify code where this value is undefined and yet a render is being attempted.

This generally happens if you have a large value a currentIndex and amount of data is then reduced. Regardless, the computations gets updated soon after. It can cause a crash sometimes which this check will mitigate.