### PR TITLE
Plv render after first draw

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recyclerlistview",
-  "version": "3.1.0-beta.3",
+  "version": "3.1.0-beta.4",
   "description": "The listview that you need and deserve. It was built for performance, uses cell recycling to achieve smooth scrolling.",
   "main": "dist/reactnative/index.js",
   "types": "dist/reactnative/index.d.ts",

--- a/scripts/publish-local.sh
+++ b/scripts/publish-local.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-TARGET=$"/Users/talhanaqvi/src/github.com/Shopify/mobile/node_modules/recyclerlistview/dist" #target-path
+TARGET=$"/Users/talha.naqvi/Documents/Work/RLV-Demo/node_modules/recyclerlistview/dist" #target-path
 
 npm run build
 

--- a/scripts/publish-local.sh
+++ b/scripts/publish-local.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-TARGET=$"/Users/talha.naqvi/Documents/Work/RLV-Demo/node_modules/recyclerlistview/dist" #target-path
+TARGET=$"/Users/talhanaqvi/src/github.com/Shopify/mobile/node_modules/recyclerlistview/dist" #target-path
 
 npm run build
 

--- a/src/core/ProgressiveListView.tsx
+++ b/src/core/ProgressiveListView.tsx
@@ -24,12 +24,23 @@ export default class ProgressiveListView extends RecyclerListView<ProgressiveLis
         renderAheadOffset: 0,
     };
     private renderAheadUdpateCallbackId?: number;
+    private isFirstLayoutComplete: boolean = false;
 
     public componentDidMount(): void {
-        if (super.componentDidMount) {
-            super.componentDidMount();
+        super.componentDidMount();
+        if (!this.props.forceNonDeterministicRendering) {
+            this.updateRenderAheadProgessively(this.getCurrentRenderAheadOffset());
         }
-        this.updateRenderAheadProgessively(this.getCurrentRenderAheadOffset());
+    }
+
+    protected onItemLayout(index: number): void {
+        if (!this.isFirstLayoutComplete) {
+            this.isFirstLayoutComplete = true;
+            if (this.props.forceNonDeterministicRendering) {
+                this.updateRenderAheadProgessively(this.getCurrentRenderAheadOffset());
+            }
+        }
+        super.onItemLayout(index);
     }
 
     private updateRenderAheadProgessively(newVal: number): void {

--- a/src/core/RecyclerListView.tsx
+++ b/src/core/RecyclerListView.tsx
@@ -391,6 +391,15 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
     protected getVirtualRenderer(): VirtualRenderer {
         return this._virtualRenderer;
     }
+    protected onItemLayout(index: number): void {
+        if (this.props.onItemLayout) {
+            this.props.onItemLayout(index);
+        }
+    }
+
+    private _onItemLayout = (index: number) => {
+        this.onItemLayout(index);
+    }
 
     private _processInitialOffset(): void {
         if (this._pendingScrollToOffset) {
@@ -630,7 +639,7 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
                     extendedState={this.props.extendedState}
                     internalSnapshot={this.state.internalSnapshot}
                     renderItemContainer={this.props.renderItemContainer}
-                    onItemLayout={this.props.onItemLayout}/>
+                    onItemLayout={this._onItemLayout}/>
             );
         }
         return null;
@@ -829,5 +838,6 @@ RecyclerListView.propTypes = {
     // This can be used to hook an itemLayoutListener to listen to which item at what index is layout.
     // To get the layout params of the item, you can use the ref to call method getLayout(index), e.x. : `this._recyclerRef.getLayout(index)`
     // but there is a catch here, since there might be a pending relayout due to which the queried layout might not be precise.
+    // Caution: RLV only listens to layout changes if forceNonDeterministicRendering is true
     onItemLayout: PropTypes.func,
 };


### PR DESCRIPTION
Based on content progressive list view sometimes starts rendering before first set of items finish their draw. This is because it just relies on requestAnimationFrame and doesn't actually wait for items to draw. This PR waits for itemLayout to happen before rendering next set of items.