### PR TITLE
Skip forceRefresh when actualOffset < 0

### DIFF
--- a/src/core/ViewabilityTracker.ts
+++ b/src/core/ViewabilityTracker.ts
@@ -75,6 +75,9 @@ export default class ViewabilityTracker {
     }
 
     public forceRefresh(): boolean {
+        if (this._actualOffset < 0) {
+            return false;
+        }
         const shouldForceScroll = this._currentOffset >= (this._maxOffset - this._windowBound);
         this.forceRefreshWithOffset(this._currentOffset);
         return shouldForceScroll;


### PR DESCRIPTION
When a scroll view animation is underway, forcing refresh (and thus resetting `scrollOffset`) interrupts the animation if there are not enough elements to fill the screen. 

With the current change, the scroll offset will not be forcefully refreshed when `this._actualOffset < 0` (that is when user is refreshing the view in case there is a refresh indicator)