### PR TITLE
fix: optional chaining for clearAll

### DIFF
--- a/src/core/VirtualRenderer.ts
+++ b/src/core/VirtualRenderer.ts
@@ -263,10 +263,10 @@ export default class VirtualRenderer {
         const newRenderStack: RenderStack = {};
         const keyToStableIdMap: { [key: string]: string } = {};
 
-        // Do not use recycle pool so that elements don't fly top to bottom or vice version
+        // Do not use recycle pool so that elements don't fly top to bottom or vice versa
         // Doing this is expensive and can draw extra items
         if (this._optimizeForAnimations) {
-            this._recyclePool.clearAll();
+            this._recyclePool?.clearAll();
         }
 
         //Compute active stable ids and stale active keys and resync render stack

--- a/src/core/VirtualRenderer.ts
+++ b/src/core/VirtualRenderer.ts
@@ -291,7 +291,7 @@ export default class VirtualRenderer {
             if (stableIdItem) {
                 if (!activeStableIds[key]) {
                     if (!this._optimizeForAnimations && this._isRecyclingEnabled) {
-                        this._recyclePool.putRecycledObject(stableIdItem.type, stableIdItem.key);
+                        this._recyclePool?.putRecycledObject(stableIdItem.type, stableIdItem.key);
                     }
                     delete this._stableIdToRenderKeyMap[key];
 
@@ -342,7 +342,7 @@ export default class VirtualRenderer {
                 const index = this._renderStack[key].dataIndex;
                 if (!ObjectUtil.isNullOrUndefined(index) && ObjectUtil.isNullOrUndefined(this._engagedIndexes[index])) {
                     const type = this._layoutProvider.getLayoutTypeForIndex(index);
-                    this._recyclePool.putRecycledObject(type, key);
+                    this._recyclePool?.putRecycledObject(type, key);
                 }
             }
         }

--- a/src/core/VirtualRenderer.ts
+++ b/src/core/VirtualRenderer.ts
@@ -265,8 +265,8 @@ export default class VirtualRenderer {
 
         // Do not use recycle pool so that elements don't fly top to bottom or vice versa
         // Doing this is expensive and can draw extra items
-        if (this._optimizeForAnimations) {
-            this._recyclePool?.clearAll();
+        if (this._optimizeForAnimations && this._recyclePool) {
+            this._recyclePool.clearAll();
         }
 
         //Compute active stable ids and stale active keys and resync render stack
@@ -291,7 +291,7 @@ export default class VirtualRenderer {
             if (stableIdItem) {
                 if (!activeStableIds[key]) {
                     if (!this._optimizeForAnimations && this._isRecyclingEnabled) {
-                        this._recyclePool?.putRecycledObject(stableIdItem.type, stableIdItem.key);
+                        this._recyclePool.putRecycledObject(stableIdItem.type, stableIdItem.key);
                     }
                     delete this._stableIdToRenderKeyMap[key];
 
@@ -342,7 +342,7 @@ export default class VirtualRenderer {
                 const index = this._renderStack[key].dataIndex;
                 if (!ObjectUtil.isNullOrUndefined(index) && ObjectUtil.isNullOrUndefined(this._engagedIndexes[index])) {
                     const type = this._layoutProvider.getLayoutTypeForIndex(index);
-                    this._recyclePool?.putRecycledObject(type, key);
+                    this._recyclePool.putRecycledObject(type, key);
                 }
             }
         }


### PR DESCRIPTION
As spoken to @naqvitalha, `recyclePool` can be null under specific circumstances (issue happens when data updates before the list has been rendered). Adding optional chaining to prevent crashing.