### PR TITLE
- [#731] Only call _forceSizeUpdate when non-deterministic rendering is used

### DIFF
--- a/src/core/RecyclerListView.tsx
+++ b/src/core/RecyclerListView.tsx
@@ -717,7 +717,8 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
             }, dim, index);
         }
 
-        if (layoutManager.overrideLayout(index, dim)) {
+        // Add extra protection for overrideLayout as it can only be called when non-deterministic rendering is used.
+        if (this.props.forceNonDeterministicRendering && layoutManager.overrideLayout(index, dim)) {
             if (this._relayoutReqIndex === -1) {
                 this._relayoutReqIndex = index;
             } else {

--- a/src/platform/reactnative/viewrenderer/ViewRenderer.tsx
+++ b/src/platform/reactnative/viewrenderer/ViewRenderer.tsx
@@ -48,10 +48,7 @@ export default class ViewRenderer extends BaseViewRenderer<any> {
         if (this.props.layoutProvider && this._layoutManagerRef) {
             if (this.props.layoutProvider.getLayoutManager() !== this._layoutManagerRef) {
                 this._layoutManagerRef = this.props.layoutProvider.getLayoutManager();
-                const oldDim = {...this._dim};
-                setTimeout(() => {
-                    this._forceSizeUpdate(oldDim);
-                }, 32);
+                this._scheduleForceSizeUpdateTimer();
             }
         }
     }
@@ -93,6 +90,18 @@ export default class ViewRenderer extends BaseViewRenderer<any> {
             this.props.onItemLayout(this.props.index);
         }
     }
+
+    private _scheduleForceSizeUpdateTimer = () => {
+        // forceSizeUpdate calls onSizeChanged which can only be called when non-deterministic rendering is used.
+        if (!this.props.forceNonDeterministicRendering) {
+            return;
+        }
+        const oldDim = {...this._dim};
+        setTimeout(() => {
+            this._forceSizeUpdate(oldDim);
+        }, 32);
+    }
+
     private _forceSizeUpdate = (dim: Dimension): void => {
         if (dim.width === this._dim.width && dim.height === this._dim.height) {
             if (this.isRendererMounted && this.props.onSizeChanged) {


### PR DESCRIPTION
Hi @naqvitalha 

This PR fixes issue #731.

The reason is because _forceSizeUpdate calls onSizeChanged which calls overrideLayout.
In the comments of overrideLayout is mentioned that it can only be called when non-deterministic rendering is used. However, there is no check to prevent this.

When overrideLayout is called with deterministic rendering, some dimensions are set with a width and height at 0 because the LayoutManager hasn't calculated/asked the dimensions yet from the LayoutProvider.

This results in the mentioned cycle:
1. componentDidUpdate is called in RecyclerListView because the state has changed. 
2. _checkAndChangeLayouts is called in componentDidUpdate
3. The check this._relayoutReqIndex >= 0 results in true which results in a call to _refreshViewability
4. _refreshViewability calls the method _queueStateRefresh
5. _queueStateRefresh calls the mentioned line again triggering this cycle again.

While the previous cycle occurs, `_generateRenderStack` is called which calls `_renderRowUsingMeta`.
Inside `_renderRowUsingMeta`, the dimensions are checked for mismatches with `_checkExpectedDimensionDiscrepancy` when deterministic rendering is used.
Because some dimensions are fixed at a width and height of 0 because of the overrideLayout function, the dimensions mismatch every time this method is called, setting `this._relayoutReqIndex ` to a `>= 0` value which makes the above cycle possible. 

Kind regards
Kevin