### PR TITLE
fix: get blank area when scrolling

### DIFF
--- a/src/core/RecyclerListView.tsx
+++ b/src/core/RecyclerListView.tsx
@@ -821,7 +821,7 @@ RecyclerListView.propTypes = {
     //Provide your own ScrollView Component. The contract for the scroll event should match the native scroll event contract, i.e.
     // scrollEvent = { nativeEvent: { contentOffset: { x: offset, y: offset } } }
     //Note: Please extend BaseScrollView to achieve expected behaviour
-    externalScrollView: PropTypes.func,
+    externalScrollView: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
 
     //Callback given when user scrolls to the end of the list or footer just becomes visible, useful in incremental loading scenarios
     onEndReached: PropTypes.func,

--- a/src/core/scrollcomponent/BaseScrollComponent.tsx
+++ b/src/core/scrollcomponent/BaseScrollComponent.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import type { ScrollViewProps } from "react-native";
 import { Dimension } from "../dependencies/LayoutProvider";
 import BaseScrollView, { ScrollEvent, ScrollViewDefaultProps } from "./BaseScrollView";
 
@@ -17,6 +18,7 @@ export interface ScrollComponentProps {
     renderContentContainer?: (props?: object, children?: React.ReactNode) => React.ReactNode | null;
     renderAheadOffset: number;
     layoutSize?: Dimension;
+    contentContainerStyle?: ScrollViewProps["contentContainerStyle"];
 }
 export default abstract class BaseScrollComponent extends React.Component<ScrollComponentProps, {}> {
     public abstract scrollTo(x: number, y: number, animate: boolean): void;

--- a/src/platform/reactnative/scrollcomponent/ScrollComponent.tsx
+++ b/src/platform/reactnative/scrollcomponent/ScrollComponent.tsx
@@ -6,6 +6,7 @@ import {
     ScrollView,
     View,
 } from "react-native";
+import type { ViewStyle } from "react-native";
 import BaseScrollComponent, { ScrollComponentProps } from "../../../core/scrollcomponent/BaseScrollComponent";
 import TSCast from "../../../utils/TSCast";
 /***

--- a/src/platform/reactnative/scrollcomponent/ScrollComponent.tsx
+++ b/src/platform/reactnative/scrollcomponent/ScrollComponent.tsx
@@ -105,11 +105,17 @@ export default class ScrollComponent extends BaseScrollComponent {
         if (event) {
             const contentOffset = event.nativeEvent.contentOffset;
             this._offset = this.props.isHorizontal ? contentOffset.x : contentOffset.y;
-            this.props.onScroll(contentOffset.x, contentOffset.y, event);
+            const { paddingTop = 0, marginTop = 0, paddingLeft = 0, marginRight = 0 } = typeof this.props.contentContainerStyle === "object"
+                ? (this.props.contentContainerStyle as ViewStyle)
+                : {};
+            const offsetY = contentOffset.y - (this.props.isHorizontal ? 0 : +paddingTop + +marginTop);
+            const offsetX = contentOffset.x - (this.props.isHorizontal ? +paddingLeft + +marginRight : 0);
+        
+            this.props.onScroll(offsetX, offsetY, event);
         }
     }
 
-    private _onLayout = (event: LayoutChangeEvent): void => {
+        private _onLayout = (event: LayoutChangeEvent): void => {
         if (this._height !== event.nativeEvent.layout.height || this._width !== event.nativeEvent.layout.width) {
             this._height = event.nativeEvent.layout.height;
             this._width = event.nativeEvent.layout.width;


### PR DESCRIPTION
# Description

Hi maintainers! 👋  

this PR is for `FlashList` and `recyclerlistview`:

### 1. if `contentContainerStyle` prop has `paddingTop` or `marginTop`, will get blank area when swiping up scrollview.

### Why 

- because during the scrolling of the view, the content container offset is not taken into account.

### How
- get the content container offset and subtract the scroll view offset. 

### Test
#### Before 


https://user-images.githubusercontent.com/37520667/186505022-218b66b2-dffc-460b-a44f-aa3c1502d165.mov

#### After

https://user-images.githubusercontent.com/37520667/186505208-eb048a8e-4c06-4251-8d22-0a1cd01a5646.mov

### 2. `renderScrollComponent` type warning.
- we need to use `renderScrollComponent` (is `externalScrollView` on recyclerlistview) prop when we use `Reanimated` with FlashList.
- it will alert this warning when using `React.forwardRef` warp a component, while it doesn't affect usage, it's very annoying.

**so we can use `PropTypes.oneOfType` and add a `PropTypes.object` type to avoid it.** 

FYI: https://github.com/Flipkart/recyclerlistview/issues/233#issuecomment-499270292

<img src="https://user-images.githubusercontent.com/37520667/184626398-bd83ebb3-0ced-4977-99d7-f6d64427b794.PNG" width="300" />





