### PR TITLE
Fix stable id extra compute and proptypes

### DIFF
--- a/src/core/RecyclerListView.tsx
+++ b/src/core/RecyclerListView.tsx
@@ -821,7 +821,7 @@ RecyclerListView.propTypes = {
     //Provide your own ScrollView Component. The contract for the scroll event should match the native scroll event contract, i.e.
     // scrollEvent = { nativeEvent: { contentOffset: { x: offset, y: offset } } }
     //Note: Please extend BaseScrollView to achieve expected behaviour
-    externalScrollView: PropTypes.func,
+    externalScrollView: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
 
     //Callback given when user scrolls to the end of the list or footer just becomes visible, useful in incremental loading scenarios
     onEndReached: PropTypes.func,

--- a/src/core/dependencies/DataProvider.ts
+++ b/src/core/dependencies/DataProvider.ts
@@ -54,7 +54,7 @@ export abstract class BaseDataProvider {
     //No need to override this one
     //If you already know the first row where rowHasChanged will be false pass it upfront to avoid loop
     public cloneWithRows(newData: any[], firstModifiedIndex?: number): DataProvider {
-        const dp = this.newInstance(this.rowHasChanged, this.getStableId);
+        const dp = this.newInstance(this.rowHasChanged, this._hasStableIds ? this.getStableId : undefined);
         const newSize = newData.length;
         const iterCount = Math.min(this._size, newSize);
         if (ObjectUtil.isNullOrUndefined(firstModifiedIndex)) {


### PR DESCRIPTION
### Description
Once the data provider is cloned it sets `hasStableIds` to true due to which extra compute is done which is useless if stable ids are indices. This PR fixes the issue. 

Also, fixed the proptype for extrenalScrollView