### PR TITLE
Increase tolerance inside layout manager

### DIFF
--- a/src/core/layoutmanager/LayoutManager.ts
+++ b/src/core/layoutmanager/LayoutManager.ts
@@ -214,7 +214,7 @@ export class WrapGridLayoutManager extends LayoutManager {
     }
 
     private _checkBounds(itemX: number, itemY: number, itemDim: Dimension, isHorizontal: boolean): boolean {
-        return isHorizontal ? (itemY + itemDim.height <= this._window.height + 1) : (itemX + itemDim.width <= this._window.width + 1);
+        return isHorizontal ? (itemY + itemDim.height <= this._window.height + 0.9) : (itemX + itemDim.width <= this._window.width + 0.9);
     }
 }
 

--- a/src/core/layoutmanager/LayoutManager.ts
+++ b/src/core/layoutmanager/LayoutManager.ts
@@ -214,7 +214,7 @@ export class WrapGridLayoutManager extends LayoutManager {
     }
 
     private _checkBounds(itemX: number, itemY: number, itemDim: Dimension, isHorizontal: boolean): boolean {
-        return isHorizontal ? (itemY + itemDim.height <= this._window.height) : (itemX + itemDim.width <= this._window.width);
+        return isHorizontal ? (itemY + itemDim.height <= this._window.height + 1) : (itemX + itemDim.width <= this._window.width + 1);
     }
 }
 


### PR DESCRIPTION
### Description
The current layout manager works well with integers but there seem to be valid cases for decimal estimates and sometimes equality checks can fail due to known floating point computing problems.

We're introducing a tolerance of 0.9px to solve those issues. We expect that people won't have rows as thin as 0.9px.