### PR TITLE
Implement `getNativeScrollRef`

### DIFF
--- a/src/core/RecyclerListView.tsx
+++ b/src/core/RecyclerListView.tsx
@@ -394,6 +394,13 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
         return null;
     }
 
+    public getNativeScrollRef(): unknown | null {
+        if (this._scrollComponent && this._scrollComponent.getNativeScrollRef) {
+          return this._scrollComponent.getNativeScrollRef();
+        }
+        return null;
+    }
+
     public renderCompat(): JSX.Element {
         //TODO:Talha
         // const {

--- a/src/core/scrollcomponent/BaseScrollComponent.tsx
+++ b/src/core/scrollcomponent/BaseScrollComponent.tsx
@@ -25,4 +25,9 @@ export default abstract class BaseScrollComponent extends React.Component<Scroll
     public getScrollableNode(): number | null {
         return null;
     }
+
+    //Override and return ref to your custom scrollview. Useful if you need to use Animated Events on the new architecture.
+    public getNativeScrollRef(): unknown | null {
+        return null;
+    }
 }

--- a/src/platform/reactnative/scrollcomponent/ScrollComponent.tsx
+++ b/src/platform/reactnative/scrollcomponent/ScrollComponent.tsx
@@ -50,6 +50,10 @@ export default class ScrollComponent extends BaseScrollComponent {
         return null;
     }
 
+    public getNativeScrollRef(): unknown | null {
+        return this._scrollViewRef;
+    }
+
     public render(): JSX.Element {
         const Scroller = TSCast.cast<ScrollView>(this.props.externalScrollView); //TSI
         const renderContentContainer = this.props.renderContentContainer ? this.props.renderContentContainer : this._defaultContainer;


### PR DESCRIPTION
This PR adds implementation for [`getNativeScrollRef`](https://reactnative.dev/docs/flatlist#getnativescrollref). It's required for compatibility with `react-native-reanimated` on the new architecture: https://github.com/software-mansion/react-native-reanimated/blob/720fefba7cd53471e98d52282c783701233861a7/src/reanimated2/hook/useAnimatedRef.ts#L26-L33