### PR TITLE
Bugfix(layoutSize) fix item not render after initial data size is empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,13 +43,13 @@
     "react-native": ">= 0.30.0"
   },
   "devDependencies": {
-    "@types/lodash.debounce": "4.0.3",
+    "@types/lodash.debounce": "4.0.8",
     "@types/prop-types": "15.5.2",
-    "@types/react-native": "0.49.5",
     "@types/react": "16.4.7",
-    "@types/resize-observer-browser": "^0.1.7",
+    "@types/react-native": "0.49.5",
+    "@types/resize-observer-browser": "0.1.7",
     "file-directives": "1.4.6",
     "tslint": "5.11.0",
-    "typescript": "3.3.1"
+    "typescript": "4.9.5"
   }
 }

--- a/src/core/RecyclerListView.tsx
+++ b/src/core/RecyclerListView.tsx
@@ -592,9 +592,9 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
         /**
          * this is to ensure that if the component does not has state and not render before
          * we still initialize the state like how we do in constructor.
-         * else return false to let the caller to call setState 
+         * else return false to let the caller to call setState
          * so the component can re-render to the correct stack
-         **/
+         */
         if (!this.state && !this.getHasRenderedOnce()) {
             this.state = {
                 internalSnapshot: {},

--- a/src/core/RecyclerListView.tsx
+++ b/src/core/RecyclerListView.tsx
@@ -589,7 +589,13 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
     }
 
     private _initStateIfRequired(stack?: RenderStack): boolean {
-        if (!this.state) {
+        /**
+         * this is to ensure that if the component does not has state and not render before
+         * we still initialize the state like how we do in constructor.
+         * else return false to let the caller to call setState 
+         * so the component can re-render to the correct stack
+         **/
+        if (!this.state && !this.getHasRenderedOnce()) {
             this.state = {
                 internalSnapshot: {},
                 renderStack: stack,

--- a/src/core/layoutmanager/LayoutManager.ts
+++ b/src/core/layoutmanager/LayoutManager.ts
@@ -74,6 +74,18 @@ export class WrapGridLayoutManager extends LayoutManager {
     public getContentDimension(): Dimension {
         return { height: this._totalHeight, width: this._totalWidth };
     }
+    /**
+     * when remove layout is called, it will remove the layout from the layouts array
+     * and if the layouts array is empty, it will reset the total height and total width to 0
+     * @param index
+     */
+     public removeLayout(index: number): void {
+        super.removeLayout(index);
+        if (this._layouts.length === 0) {
+            this._totalHeight = 0;
+            this._totalWidth = 0;
+        }
+    }
 
     public getLayouts(): Layout[] {
         return this._layouts;

--- a/src/utils/ComponentCompat.ts
+++ b/src/utils/ComponentCompat.ts
@@ -16,6 +16,14 @@ export abstract class ComponentCompat<T1 = {}, T2 = {}, SS = any> extends React.
         return true;
     }
 
+    /**
+     * allow the extended component to access _hasRenderedOnce flag
+     * to ensure that the component has rendered at least once
+     * @returns _hasRenderedOnce
+     */
+    public getHasRenderedOnce(): boolean {
+        return this._hasRenderedOnce;
+    }
     //setState inside will not update the existing cycle, not a true replacement for componentWillReceiveProps
     public componentWillReceivePropsCompat(newProps: T1): void {
         //no op


### PR DESCRIPTION
This PR address two issues
### Issue 1
this will fix flash-list issue https://github.com/Shopify/flash-list/issues/784


if layoutSize is provided, items doesn't render if the initial data size is empty.

add new function to componentCompact to allow extended component to had access to the _hasRenderOnce

only assign the state is the component never get render before

Here is the screen capture i had for the Shopify POS that reproduce the issue 

BEFORE

https://github.com/Flipkart/recyclerlistview/assets/17916546/dfc443b3-93e7-479c-b82b-f93d2a7fa719

AFTER

https://github.com/Flipkart/recyclerlistview/assets/17916546/d1ba3998-ec04-45b7-a2e2-8aacec95e253


### Issue 2

after fixing  issue 1,  when navigate to the list. the content size will increase by the estimatedItemSize

here is the screenshot and video demo on SHOPIFY POS on the issue 

![image](https://github.com/Flipkart/recyclerlistview/assets/17916546/1613c99b-d20d-48c5-98e2-dc1e027f4364)


https://github.com/Flipkart/recyclerlistview/assets/17916546/68504344-f83a-43a6-9d28-f4013e989a41



