### PR TITLE
Improve performance and user experience with React.startTransition 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@types/lodash.debounce": "4.0.8",
     "@types/prop-types": "15.5.2",
-    "@types/react": "16.4.7",
+    "@types/react": "^18.3.3",
     "@types/react-native": "0.49.5",
     "@types/resize-observer-browser": "0.1.7",
     "file-directives": "1.4.6",

--- a/src/core/RecyclerListView.tsx
+++ b/src/core/RecyclerListView.tsx
@@ -38,11 +38,11 @@ import ItemAnimator, { BaseItemAnimator } from "./ItemAnimator";
 import { DebugHandlers } from "..";
 import { ComponentCompat } from "../utils/ComponentCompat";
 //#if [REACT-NATIVE]
-import ScrollComponent from "../platform/reactnative/scrollcomponent/ScrollComponent";
-import ViewRenderer from "../platform/reactnative/viewrenderer/ViewRenderer";
-import { DefaultJSItemAnimator as DefaultItemAnimator } from "../platform/reactnative/itemanimators/defaultjsanimator/DefaultJSItemAnimator";
-import { Platform, ScrollView } from "react-native";
-const IS_WEB = !Platform || Platform.OS === "web";
+//import ScrollComponent from "../platform/reactnative/scrollcomponent/ScrollComponent";
+//import ViewRenderer from "../platform/reactnative/viewrenderer/ViewRenderer";
+//import { DefaultJSItemAnimator as DefaultItemAnimator } from "../platform/reactnative/itemanimators/defaultjsanimator/DefaultJSItemAnimator";
+//import { Platform, ScrollView } from "react-native";
+//const IS_WEB = !Platform || Platform.OS === "web";
 //#endif
 
 /***
@@ -50,11 +50,11 @@ const IS_WEB = !Platform || Platform.OS === "web";
  */
 
 //#if [WEB]
-//import ScrollComponent from "../platform/web/scrollcomponent/ScrollComponent";
-//import ViewRenderer from "../platform/web/viewrenderer/ViewRenderer";
-//import { DefaultWebItemAnimator as DefaultItemAnimator } from "../platform/web/itemanimators/DefaultWebItemAnimator";
-//const IS_WEB = true;
-//type ScrollView = unknown;
+import ScrollComponent from "../platform/web/scrollcomponent/ScrollComponent";
+import ViewRenderer from "../platform/web/viewrenderer/ViewRenderer";
+import { DefaultWebItemAnimator as DefaultItemAnimator } from "../platform/web/itemanimators/DefaultWebItemAnimator";
+const IS_WEB = true;
+type ScrollView = unknown;
 //#endif
 
 /***
@@ -557,13 +557,19 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
     }
 
     private _queueStateRefresh(): void {
-        this.refreshRequestDebouncer(() => {
+        const refreshStates = () => {
             if (this._isMounted) {
                 this.setState((prevState) => {
                     return prevState;
                 });
             }
-        });
+        };
+
+        if (typeof React?.startTransition !== "undefined") {
+            React.startTransition(refreshStates);
+        } else {
+            this.refreshRequestDebouncer(refreshStates);
+        }
     }
 
     private _onSizeChanged = (layout: Dimension): void => {


### PR DESCRIPTION
## React.startTransition vs. Lodash Debounce

**React.startTransition** offers a more granular and React-specific approach to optimizing UI updates compared to Lodash debounce. By marking updates as transitions, React can prioritize critical UI changes while deferring less important ones, resulting in a smoother user experience.
 
**Key benefits:**

* **Prioritizes critical updates:** Unlike debounce which delays all updates, `startTransition` allows immediate rendering of essential UI changes.
* **React-specific optimization:** Leverages React's internal mechanisms for efficient updates.
* **Granular control:** Apply transitions selectively for fine-tuned performance optimization. 

By using `startTransition`, you can achieve a more responsive and fluid user interface while effectively managing UI updates. 

Ref-: https://github.com/reactwg/react-18/discussions/41
---

I am extremely sorry if I made any mistakes :)