### PR TITLE
Fix _queueStateRefresh not working after previously being frozen by react-freeze

### DIFF
--- a/src/core/RecyclerListView.tsx
+++ b/src/core/RecyclerListView.tsx
@@ -239,6 +239,7 @@ export default class RecyclerListView<P extends RecyclerListViewProps, S extends
     }
 
     public componentDidMount(): void {
+        this._isMounted = true;
         if (this._initComplete) {
             this._processInitialOffset();
             this._processOnEndReached();


### PR DESCRIPTION
When the list is frozen by `react-freeze`, `componentWillUnmount` is called which sets `_isMounted` to `false`. When unfrozen, `_isMounted` stays at `false`. This causes `_queueStateRefresh` to not working which prevents the relayouting.

This PR fixes it by resetting `_isMounted` to `true` in `componentDidMount`.