### PR TITLE
Fix: Update ref handling in StickyContainer for React 19 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recyclerlistview",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "The listview that you need and deserve. It was built for performance, uses cell recycling to achieve smooth scrolling.",
   "main": "dist/reactnative/index.js",
   "types": "dist/reactnative/index.d.ts",

--- a/src/core/StickyContainer.tsx
+++ b/src/core/StickyContainer.tsx
@@ -126,9 +126,10 @@ export default class StickyContainer<P extends StickyContainerProps> extends Com
 
     private _getRecyclerRef = (recycler: any) => {
         this._recyclerRef = recycler as (RecyclerListView<RecyclerListViewProps, RecyclerListViewState> | undefined);
-        if (this.props.children.ref) {
-            if (typeof this.props.children.ref === "function") {
-                (this.props.children).ref(recycler);
+        const childRef = this.props.children.props.ref || this.props.children.ref;
+        if (childRef) {
+            if (typeof childRef === "function") {
+                childRef(recycler);
             } else {
                 throw new CustomError(RecyclerListViewExceptions.refNotAsFunctionException);
             }


### PR DESCRIPTION
React 19 doesn't allow direct access to ref from the element. This is causing warnings in FlashList. This PR fixes the issue.
Ref Shopify/flash-list#1543
