### PR TITLE
fix onLayout floating point numbers using roundToNearestPixel

### DIFF
--- a/src/platform/reactnative/scrollcomponent/ScrollComponent.tsx
+++ b/src/platform/reactnative/scrollcomponent/ScrollComponent.tsx
@@ -5,6 +5,7 @@ import {
     NativeSyntheticEvent,
     ScrollView,
     View,
+    PixelRatio,
 } from "react-native";
 import BaseScrollComponent, { ScrollComponentProps } from "../../../core/scrollcomponent/BaseScrollComponent";
 import TSCast from "../../../utils/TSCast";
@@ -114,9 +115,11 @@ export default class ScrollComponent extends BaseScrollComponent {
     }
 
     private _onLayout = (event: LayoutChangeEvent): void => {
-        if (this._height !== event.nativeEvent.layout.height || this._width !== event.nativeEvent.layout.width) {
-            this._height = event.nativeEvent.layout.height;
-            this._width = event.nativeEvent.layout.width;
+        const layoutHeight = PixelRatio.roundToNearestPixel(event.nativeEvent.layout.height);
+        const layoutWidth = PixelRatio.roundToNearestPixel(event.nativeEvent.layout.width);
+        if (this._height !== layoutHeight || this._width !== layoutWidth) {
+            this._height = layoutHeight;
+            this._width = layoutWidth;
             if (this.props.onSizeChanged) {
                 this._isSizeChangedCalledOnce = true;
                 this.props.onSizeChanged(event.nativeEvent.layout);

--- a/src/platform/reactnative/viewrenderer/ViewRenderer.tsx
+++ b/src/platform/reactnative/viewrenderer/ViewRenderer.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { LayoutChangeEvent, View, ViewProperties } from "react-native";
+import { LayoutChangeEvent, View, ViewProperties, PixelRatio } from "react-native";
 import { Dimension } from "../../../core/dependencies/LayoutProvider";
 import { LayoutManager } from "../../../core/layoutmanager/LayoutManager";
 import BaseViewRenderer, { ViewRendererProps } from "../../../core/viewrenderer/BaseViewRenderer";
@@ -76,11 +76,13 @@ export default class ViewRenderer extends BaseViewRenderer<any> {
         //Preventing layout thrashing in super fast scrolls where RN messes up onLayout event
         const xDiff = Math.abs(this.props.x - event.nativeEvent.layout.x);
         const yDiff = Math.abs(this.props.y - event.nativeEvent.layout.y);
+        const layoutHeight = PixelRatio.roundToNearestPixel(event.nativeEvent.layout.height);
+        const layoutWidth = PixelRatio.roundToNearestPixel(event.nativeEvent.layout.width);
         if (xDiff < 1 && yDiff < 1 &&
-            (this.props.height !== event.nativeEvent.layout.height ||
-                this.props.width !== event.nativeEvent.layout.width)) {
-            this._dim.height = event.nativeEvent.layout.height;
-            this._dim.width = event.nativeEvent.layout.width;
+            (this.props.height !== layoutHeight ||
+                this.props.width !== layoutWidth)) {
+            this._dim.height = layoutHeight;
+            this._dim.width = layoutWidth;
             if (this.props.onSizeChanged) {
                 this.props.onSizeChanged(this._dim, this.props.index);
             }


### PR DESCRIPTION
Hi!

I've been using RecyclerListView (and now FlashList) for many years in my project.

I've applied many patches to address different issues, but I’ve noticed that many of them share the same root cause: a probable floating-point precision issue related to React Native's `onLayout` event.

---

_Here’s an example of the `event.nativeEvent.layout` output for seven identical horizontal list components with different data:_

<img width="374" alt="Capture d’écran 2025-03-18 à 16 29 38" src="https://github.com/user-attachments/assets/a6056af3-ed42-4c5a-9667-dcf8c1616739" />

_Those affected by the floating-point issue experienced problems such as being unable to click on an item or scroll to the last item_

---

There are many ways to handle this issue, but we don’t want to rely on external dependencies. Instead, we want to track only the changes that produce actual visual differences on screen.

In other words, we don’t want to simply `Math.round` the values, as that would prevent us from detecting changes smaller than 1 dp. On a device with a pixel ratio of 3, we need to track changes as small as 0.333333 (which corresponds to `StyleSheet.hairlineWidth`).

That’s why I believe `PixelRatio.roundToNearestPixel` is a good candidate for this fix: regardless of the reason for the onLayout changes, if a change isn’t significant enough to produce a visible difference on screen, then no action should be taken.