### PR TITLE
Pass a pre-calculated height

### DIFF
--- a/src/core/scrollcomponent/BaseScrollComponent.tsx
+++ b/src/core/scrollcomponent/BaseScrollComponent.tsx
@@ -18,6 +18,7 @@ export interface ScrollComponentProps {
     renderContentContainer?: (props?: object, children?: React.ReactNode) => React.ReactNode | null;
     renderAheadOffset: number;
     layoutSize?: Dimension;
+    estimatedHeightSize?: number;
 }
 export default abstract class BaseScrollComponent extends React.Component<ScrollComponentProps, {}> {
     public abstract scrollTo(x: number, y: number, animate: boolean): void;

--- a/src/platform/reactnative/scrollcomponent/ScrollComponent.tsx
+++ b/src/platform/reactnative/scrollcomponent/ScrollComponent.tsx
@@ -114,12 +114,13 @@ export default class ScrollComponent extends BaseScrollComponent {
     }
 
     private _onLayout = (event: LayoutChangeEvent): void => {
-        if (this._height !== event.nativeEvent.layout.height || this._width !== event.nativeEvent.layout.width) {
-            this._height = event.nativeEvent.layout.height;
+        const estimatedHeightSize = this.props.estimatedHeightSize || event.nativeEvent.layout.height;
+        if (this._height !== estimatedHeightSize || this._width !== event.nativeEvent.layout.width) {
+            this._height = estimatedHeightSize;
             this._width = event.nativeEvent.layout.width;
             if (this.props.onSizeChanged) {
                 this._isSizeChangedCalledOnce = true;
-                this.props.onSizeChanged(event.nativeEvent.layout);
+                this.props.onSizeChanged({...event.nativeEvent.layout, height: estimatedHeightSize });
             }
         }
         if (this.props.onLayout) {


### PR DESCRIPTION
Working on Expensify I found that sometimes the calculated hight was breaking the recycling. I created a patch, but I think this addition can help others.

More context here: https://github.com/Expensify/App/issues/56980
