### PR TITLE
Fix/cannot read property of undefined

### DIFF
--- a/src/core/layoutmanager/GridLayoutManager.ts
+++ b/src/core/layoutmanager/GridLayoutManager.ts
@@ -43,7 +43,6 @@ export class GridLayoutManager extends WrapGridLayoutManager {
       if (layout) {
         const heightDiff = Math.abs(dim.height - layout.height);
         const widthDiff = Math.abs(dim.width - layout.width);
-
         if (this._isGridHorizontal) {
           if (heightDiff < this._acceptableRelayoutDelta) {
             if (widthDiff === 0) {

--- a/src/core/layoutmanager/GridLayoutManager.ts
+++ b/src/core/layoutmanager/GridLayoutManager.ts
@@ -39,10 +39,11 @@ export class GridLayoutManager extends WrapGridLayoutManager {
       // This causes the layouting to behave weirdly as the new dimension might not adhere to the spans and the cells arrange themselves differently
       // So, whenever we have layouts for a certain index, we explicitly override the dimension to those very layout values
       // and call super so as to set the overridden flag as true
-      const layout = this.getLayouts()[index];
-      const heightDiff = Math.abs(dim.height - layout.height);
-      const widthDiff = Math.abs(dim.width - layout.width);
+      const layout = this.getLayouts()[index] as Layout | undefined;
       if (layout) {
+        const heightDiff = Math.abs(dim.height - layout.height);
+        const widthDiff = Math.abs(dim.width - layout.width);
+
         if (this._isGridHorizontal) {
           if (heightDiff < this._acceptableRelayoutDelta) {
             if (widthDiff === 0) {


### PR DESCRIPTION
Hi there
We've received an unhanded exception while using https://github.com/shopify/flash-list

This PR aims to fix the unhandled exception and add a type guard to prevent future such issues in a parent library

There're no repro steps, because it's just a single log in Sentry, but the applied fix is small and makes sense, to access `layout` only when it's true, instead of access it's properties before the check is performed

Attaching a screenshot of the error as a proof:
<img width="1077" height="824" alt="Screenshot 2026-01-16 at 10 42 22" src="https://github.com/user-attachments/assets/ea5e1da4-ab80-4935-9123-8124f6b24755" />
